### PR TITLE
Typo and consistency fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 from setuptools import setup, find_packages
 
 setup(name='flanker',
-      version="0.3.2",
-      description="Mailgun Parsing Tools",
+      version='0.3.2',
+      description='Mailgun Parsing Tools',
       long_description='',
       classifiers=[],
       keywords='',


### PR DESCRIPTION
Just a couple of minor fixes. You might also want to add a short description and URL, because currently `flanker` is shown as follows when listed as a repository in search:

![screen shot 2013-11-19 at 14 19 10](https://f.cloud.github.com/assets/2316326/1572816/98051664-5125-11e3-92a2-697d349e203a.png)

Whereas with a description it would be much more informative, for example look at `requests`:

![screen shot 2013-11-19 at 14 20 46](https://f.cloud.github.com/assets/2316326/1572824/d1535912-5125-11e3-8357-8ef01c87025c.png)
