### PR TITLE
Allow multiple non-consecutive dots in a Hotmail address

### DIFF
--- a/flanker/addresslib/plugins/hotmail.py
+++ b/flanker/addresslib/plugins/hotmail.py
@@ -10,7 +10,6 @@
         must end with letter, number, hyphen (-), or underscore (_)
         must use letters, numbers, periods (.), hypens (-), or underscores (_)
         only one plus (+) is allowed
-        only one dot (.) is allowed
         case is ignored
 
     Grammar:
@@ -25,7 +24,7 @@
 
     Other limitations:
 
-        1. No more than a single dot (.) is allowed in the local-part
+        1. Only one consecutive period (.) is allowed in the local-part
         2. Length of local-part must be no more than 64 characters, and no
            less than 1 characters.
 
@@ -47,6 +46,10 @@ HOTMAIL_SUFFIX  = re.compile(r'''
 
 PLUS            = re.compile(r'''
                             \+
+                            ''', re.MULTILINE | re.VERBOSE)
+
+PERIODS         = re.compile(r'''
+                            \.{2,}
                             ''', re.MULTILINE | re.VERBOSE)
 
 
@@ -72,12 +75,12 @@ def validate(localpart):
     if HOTMAIL_SUFFIX.match(real_localpart[-1]) is None:
         return False
 
-    # no more than one dot (.)
-    if localpart.count('.') > 1:
-        return False
-
     # no more than one plus (+)
     if localpart.count('+') > 1:
+        return False
+
+    # no consecutive periods (..)
+    if PERIODS.search(localpart):
         return False
 
     # grammar check

--- a/tests/addresslib/plugins/hotmail_test.py
+++ b/tests/addresslib/plugins/hotmail_test.py
@@ -64,15 +64,16 @@ def test_hotmail_pass():
             addr = address.validate_address(localpart + DOMAIN)
             assert_not_equal(addr, None)
 
-        # only zero or one dot (.) or plus allowed
+        # only zero or one plus allowed
         for i in range(0, 2):
-            localpart = 'aa' + '.'*i + '00'
-            addr = address.validate_address(localpart + DOMAIN)
-            assert_not_equal(addr, None)
-
             localpart = 'aa' + '+'*i + '00'
             addr = address.validate_address(localpart + DOMAIN)
             assert_not_equal(addr, None)
+
+        # allow multiple periods
+        localpart = 'aa.bb.00'
+        addr = address.validate_address(localpart + DOMAIN)
+        assert_not_equal(addr, None)
 
 
 def test_hotmail_fail():
@@ -112,7 +113,7 @@ def test_hotmail_fail():
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)
 
-        # no more than 1 dot (.) or plus (+) allowed
+        # no more than 1 consecutive dot (.) or plus (+) allowed
         for i in range(2, 4):
             localpart = 'aa' + '.'*i + '00'
             addr = address.validate_address(localpart + DOMAIN)


### PR DESCRIPTION
Hotmail allows multiple dots in the local part of the e-mail address as long as they aren't consecutive.
