### PR TITLE
Adding Django Cache Option

### DIFF
--- a/docs/User Manual.md
+++ b/docs/User Manual.md
@@ -233,6 +233,13 @@ foo@mailgun.com
 >>> flanker.addresslib.set_mx_cache(custom_mx_cache_library)
 ```
 
+###### Example: Use the Django Cache Framework
+
+```python
+>>> from flanker import addresslib
+>>> addresslib.set_mx_cache(addresslib.drivers.django_driver.DjangoCache())
+```
+
 ### MIME Parsing
 
 `flanker.mime` is a complete MIME handling package for parsing and creating MIME

--- a/flanker/addresslib/drivers/django_driver.py
+++ b/flanker/addresslib/drivers/django_driver.py
@@ -1,0 +1,54 @@
+"""Django Cache Driver"""
+
+import collections
+try:
+    from django.core.cache import get_cache
+except ImportError:
+    pass
+
+class DjangoCache(collections.MutableMapping):
+    """Cache that uses the Django Cache Backend"""
+    def __init__(self, cache='default', prefix='mxr:', ttl=604800):
+        """Initalize the cache
+
+        Arguments:
+
+        * cache -- the name of the Django cache to use (if not the default
+                   cache)
+        * prefix -- the prefix to use when setting mx record keys (defaults to
+                    'mxr:')
+        * ttl -- the timeout for mx record caches in seconds (defaults to 1
+                 week)
+        """
+        self.prefix = prefix
+        self.ttl = ttl
+        self.cache = get_cache(cache)
+
+    def __getitem__(self, key):
+        """Get an item from the cache"""
+        return self.cache.get(self.__keytransform__(key))
+
+    def __setitem__(self, key, value):
+        """Set a cache item"""
+        return self.cache.set(self.__keytransform__(key), value, self.ttl)
+
+    def __delitem__(self, key):
+        """Delete an item from the cache"""
+        self.cache.delete(self.__keytransform__(key))
+
+    def __keytransform__(self, key):
+        """Generate the key name"""
+        return ''.join([self.prefix, str(key)])
+
+    def __value_generator__(self, keys):
+        """Generator to pull multiple keys"""
+        for key in keys:
+            yield self.cache.get(key)
+
+    def __iter__(self):
+        """Cache Iterator (not available with Django Cache)"""
+        return iter([])
+
+    def __len__(self):
+        """Cache Length (not available with Django Cache)"""
+        return 0


### PR DESCRIPTION
This adds an option that lets you fall back to the django cache if you don't want to use redis directly. Doesn't require django, but provides the option.

I didn't spend a ton of time on tests or documentation since I'm not 100% sure how you'd like to go forward with either of these. It isn't an especially complex addition and there aren't tests for the redis implementation so I think we might be OK there, but documentation wise I think there might be room for more beyond the small bit I added and the information in the cache's docstring.

Thanks
