### PR TITLE
Centralize Unicode and utf8 utilities to utils.py

### DIFF
--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -1,6 +1,6 @@
-import chardet
 import regex as re
 from flanker.mime.message import errors
+from flanker.utils import to_utf8, to_unicode
 
 def convert_to_unicode(charset, value):
     #in case of unicode we have nothing to do
@@ -9,26 +9,7 @@ def convert_to_unicode(charset, value):
 
     charset = _translate_charset(charset)
 
-    #try to decode string strictly
-    try:
-        return value.decode(charset, 'strict')
-    except (UnicodeError, LookupError):
-        try:
-            #try guess encoding and decode strictly
-            return guess_and_convert(value)
-        except Exception:
-            return value.decode(charset, 'ignore')
-
-
-def guess_and_convert(data):
-    charset = chardet.detect(data)
-    if not charset['encoding']:
-        raise errors.DecodingError("Failed to guess encoding for %s" %(data, ))
-    try:
-        return data.decode(charset["encoding"], 'strict')
-    except Exception, e:
-        raise errors.DecodingError(str(e))
-
+    return to_unicode(value, charset=charset)
 
 def _translate_charset(charset):
     """Translates crappy charset into Python analogue (if supported).
@@ -51,7 +32,3 @@ def _translate_charset(charset):
 
     return charset
 
-
-RE_7BIT = ''
-def is_7bit_string():
-    pass

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -51,7 +51,7 @@ def encode_unstructured(name, value):
             return encode_address_header(name, value)
         else:
             return Header(
-                value.encode("utf-8"), "utf-8", header_name=name).encode(
+                to_utf8(value), "utf-8", header_name=name).encode(
                 splitchars=' ;,')
 
 

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -4,7 +4,7 @@ from collections import deque
 from flanker.mime.message.headers import encodedword, parametrized
 from flanker.mime.message.headers.wrappers import ContentType, WithParams
 from flanker.mime.message.errors import DecodingError
-from flanker.utils import is_pure_ascii
+from flanker.utils import to_unicode, is_pure_ascii
 
 MAX_LINE_LENGTH = 10000
 
@@ -122,12 +122,3 @@ def split2(header):
     else:
         return (None, None)
 
-
-def to_unicode(val):
-    if isinstance(val, unicode):
-        return val
-    else:
-        try:
-            return unicode(val, 'utf-8', 'strict')
-        except UnicodeDecodeError:
-            raise DecodingError("Non ascii or utf-8 header value")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -40,6 +40,7 @@ RELATIVE = open(fixture_file("messages/relative.eml")).read()
 IPHONE = open(fixture_file("messages/iphone.eml")).read()
 
 MULTIPART = open(fixture_file("messages/multipart.eml")).read()
+FROM_ENCODING = open(fixture_file("messages/from-encoding.eml")).read()
 NO_CTYPE = open(fixture_file("messages/no-ctype.eml")).read()
 ENCLOSED = open(fixture_file("messages/enclosed.eml")).read()
 ENCLOSED_BROKEN_BOUNDARY = open(

--- a/tests/fixtures/messages/from-encoding.eml
+++ b/tests/fixtures/messages/from-encoding.eml
@@ -1,0 +1,36 @@
+Received: (from majordom@localhost)
+	by hyperreal.org (8.8.5/8.8.5) id NAA18142;
+	Sat, 12 Jul 1997 13:10:53 -0700 (PDT)
+Received: from linteuto.teuto.de (root@linteuto.teuto.de [194.77.23.26])
+	by hyperreal.org (8.8.5/8.8.5) with ESMTP id NAA18138
+	for <new-httpd@apache.org>; Sat, 12 Jul 1997 13:10:48 -0700 (PDT)
+Received: from suri.teuto.de (ppp-neu24.teuto.de [194.77.23.152])
+	by linteuto.teuto.de (8.8.5/8.8.5) with ESMTP id WAA30612
+	for <new-httpd@apache.org>; Sat, 12 Jul 1997 22:10:45 +0200
+Message-ID: <33C7E4E1.2A12445E@blank.pages.de>
+Date: Sat, 12 Jul 1997 22:11:13 +0200
+From: "Ingo Lütkebohle" <ingo@blank.pages.de>
+Organization: dev/consulting GmbH
+X-Mailer: Mozilla 4.01 [en] (Win95; I)
+MIME-Version: 1.0
+To: new-httpd@apache.org
+Subject: Re: running server as root (Was: Re: PUT method)
+X-Priority: 3 (Normal)
+References: <Pine.BSF.3.95q.970712135859.28530B-100000@valis.worldgate.com>
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: 7bit
+Sender: new-httpd-owner@apache.org
+Precedence: bulk
+Reply-To: new-httpd@apache.org
+
+Marc Slemko wrote:
+> If you have a real uid of root, then if someone finds something like a
+> buffer overflow in the code that is exploitable they can get root.  Sure,
+> takes another couple of syscalls but no big deal.  That is not good.
+
+Isn't that the case for almost every other server you care to mention?
+What about switching to an EUID of nobody early in the request
+processing stage?
+
+---/dev/il
+

--- a/tests/mime/message/headers/encodedword_test.py
+++ b/tests/mime/message/headers/encodedword_test.py
@@ -3,6 +3,7 @@
 from nose.tools import *
 from mock import *
 from flanker.mime.message.headers import encodedword
+from flanker import utils
 from flanker.mime.message import errors, charsets
 
 def encoded_word_test():
@@ -130,7 +131,7 @@ def various_encodings_test():
     eq_(u'Evaneos-Concepción.pdf', encodedword.mime_to_unicode(v))
 
 
-@patch.object(charsets, 'guess_and_convert', Mock(side_effect=errors.EncodingError()))
+@patch.object(utils, '_guess_and_convert', Mock(side_effect=errors.EncodingError()))
 def test_convert_to_utf8_unknown_encoding():
     v = "abc\x80def"
     eq_(u"abc\u20acdef", charsets.convert_to_unicode("windows-874", v))

--- a/tests/mime/message/scanner_test.py
+++ b/tests/mime/message/scanner_test.py
@@ -138,6 +138,11 @@ Body."""
     assert_raises(DecodingError, lambda x: message.headers, 1)
 
 
+def test_non_ascii_from():
+    message = scan(FROM_ENCODING)
+    eq_(u'"Ingo Lütkebohle" <ingo@blank.pages.de>', message.headers.get('from'))
+
+
 def notification_about_multipart_test():
     message = scan(NOTIFICATION)
     eq_(3, len(message.parts))


### PR DESCRIPTION
![](http://25.media.tumblr.com/abaeeb7fa33a768caace00453a224d18/tumblr_muctp0pis21sqhdk6o1_400.gif)
- Tries to make `to_unicode` just get things into `unicode` type while `to_utf8` gets things into a `str` of utf-8 bytes.
- Don't think this is perfect, would love feedback.
- But it does pass all tests
