### PR TITLE
Impossible to install due to version pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,15 @@ setup(name='flanker',
       include_package_data=True,
       zip_safe=True,
       install_requires=[
-          'chardet==1.0.1',
-          'dnsq==1.0',
-          'expiringdict==1.0',
-          'mock==1.0.1',
-          'nose==1.2.1',
-          'Paste==1.7.5',
-          'redis==2.7.1',
+          'chardet',
+          'dnsq',
+          'expiringdict',
+          'mock',
+          'nose',
+          'Paste',
+          'redis',
           # IMPORTANT! Newer regex versions are a lot slower for
           # mime parsing (100x slower) so keep it as-is for now.
-          'regex==0.1.20110315',
+          'regex<=0.1.20110315',
       ],
       )


### PR DESCRIPTION
flank currently uses exact version pins in its setup.py:

``` python
      install_requires=[
          'chardet==1.0.1',
          'dnsq==1.0',
          'expiringdict==1.0',
          'mock==1.0.1',
          'nose==1.2.1',
          'Paste==1.7.5',
          'redis==2.7.1',
          # IMPORTANT! Newer regex versions are a lot slower for
          # mime parsing (100x slower) so keep it as-is for now.
          'regex==0.1.20110315',
      ],
```

This makes it completely impossible to use flanker in environments that require a different version of any of those dependencies.

If you have a minimum version requirement use that in your requirements, otherwise do not pin a version as well. But please please please never use exact version pins.

If you need exact versions for you environment use something like [pip requirements files](http://www.pip-installer.org/en/latest/cookbook.html#requirements-files) possible combined with a local [virtualenv](http://www.virtualenv.org/en/latest/), or [zc.buildout](http://www.buildout.org/en/latest/).
