### PR TITLE
Fix MANIFEST syntax error.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include *.py
+recursive-include tests *.py
 include README.md LICENSE


### PR DESCRIPTION
The recursive-include statements requires a directory as its first option.
Since package source is always include I set this to the tests directory.
