### PR TITLE
Use WebOb's multidict instead of Paste

### DIFF
--- a/flanker/mime/message/headers/headers.py
+++ b/flanker/mime/message/headers/headers.py
@@ -1,4 +1,4 @@
-from paste.util.multidict import MultiDict
+from webob.multidict import MultiDict
 from flanker.mime.message.headers.parsing import normalize, parse_stream
 from flanker.mime.message.headers.encoding import to_mime
 from flanker.mime.message.errors import EncodingError

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='flanker',
           'expiringdict==1.0',
           'mock==1.0.1',
           'nose==1.2.1',
-          'Paste==1.7.5',
+          'WebOb',
           'redis==2.7.1',
           # IMPORTANT! Newer regex versions are a lot slower for
           # mime parsing (100x slower) so keep it as-is for now.


### PR DESCRIPTION
Paste is obsolete these days: it has not been maintained in years. It code has been split up into multiple other packages that are actively maintained and widely used.

MultiDict has been moved to [WebOb[(http://webob.org/). It would be nice if flanker can switch to that (just change the import too `webob.multidict.MultiDict` so we can get rid of the paste dependency again.
