### PR TITLE
Account for a cached value of False when validating.

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -197,7 +197,7 @@ def validate_address(addr_spec, metrics=False):
     mtimes['mx_lookup'] = mx_metrics['mx_lookup']
     mtimes['dns_lookup'] = mx_metrics['dns_lookup']
     mtimes['mx_conn'] = mx_metrics['mx_conn']
-    if exchanger is None:
+    if exchanger in (None, False):
         return None, mtimes
 
     # lookup custom local-part grammar if it exists
@@ -255,7 +255,7 @@ def validate_list(addr_list, as_tuple=False, metrics=False):
         mtimes['dns_lookup'] += mx_metrics['dns_lookup']
         mtimes['mx_conn'] += mx_metrics['mx_conn']
 
-        if exchanger is None:
+        if exchanger in (None, False):
             ulist.append(paddr.full_spec())
             continue
 


### PR DESCRIPTION
Hi there,

I had an issue on django-flanker that I've traced to flanker itself.

https://github.com/dmpayton/django-flanker/issues/2

If `connect_to_mail_exchanger` throws an exception or fails to connect for whatever, it returns None and `mail_exchanger_lookup` will set `mx_cache[domain]` to False.

This is not accounted for on subsequent calls to `validate_address`. If the cached value is None, it returns None, otherwise it continues. If the cached value is False, it throws the following exception:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/derek/dev/django-flanker/flanker/utils.py", line 99, in wrapper
    return_value = f(*args, **kwargs)
  File "/home/derek/dev/django-flanker/flanker/addresslib/address.py", line 205, in validate_address
    plugin = flanker.addresslib.validate.plugin_for_esp(exchanger)
  File "/home/derek/dev/django-flanker/flanker/addresslib/validate.py", line 108, in plugin_for_esp
    if grammar[0].match(mail_exchanger):
TypeError: expected string or buffer
```

This patch simply returns None if the cached value is False.
