### PR TITLE
Don't declare mock/nose as production dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ setup(name='flanker',
           'chardet>=1.0.1',
           'dnsq>=1.1',
           'expiringdict>=1.1',
-          'mock>=1.0.1',
-          'nose>=1.2.1',
           'Paste>=1.7.5',
           'redis>=2.7.1',
           # IMPORTANT! Newer regex versions are a lot slower for

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,6 @@ envlist = py26, py27
 
 [testenv]
 commands = nosetests
+deps =
+    mock>=1.0.1
+    nose>=1.2.1


### PR DESCRIPTION
Instead, add them to the tox.ini file, so they will be used for testing automatically, but won't be added as a dependency when deploying flanker to production.
