### PR TITLE
Allow `Content-Type` header value be of ContentType class

### DIFF
--- a/flanker/mime/message/fallback/part.py
+++ b/flanker/mime/message/fallback/part.py
@@ -31,6 +31,9 @@ class FallbackMimePart(RichPartMixin):
 
     @property
     def content_type(self):
+        content_type = self._headers['Content-Type']
+        if isinstance(content_type, ContentType):
+            return content_type
         return ContentType(
             self._m.get_content_maintype(),
             self._m.get_content_subtype(),


### PR DESCRIPTION
It looks like somewhere in the code that uses Flanker we set the Content-Type header to a value of ContentType class. I have not been able to find that place but an exception traceback clearly states that it is indeed what happens. This is not a good thing to fix errors of a code that uses a library by modifying the library itself, but nethertheless I propose this change to stop those errors occurring everyday from happening as soon as possible.  
