### PR TITLE
Fix FallbackHeaders.transform

### DIFF
--- a/tests/mime/message/fallback/fallback_test.py
+++ b/tests/mime/message/fallback/fallback_test.py
@@ -265,7 +265,7 @@ def message_headers_transform_test():
          ('X-Authentication-Results', 'm'),
          ('X-Dkim-Signature', 'a'),
          ('X-Domainkey-Signature', 'a'),
-         ('X-Content-Type', ('multipart/mixed',)),
+         ('X-Content-Type', 'm'),
          ('X-Mime-Version', '1'),
          ('X-Received', 'b'),
          ('X-Received', 'f'),


### PR DESCRIPTION
FallbackHeaders transform function should operate on the headers of the underlying email.Message.
