### PR TITLE
Fix for decoding errors if the list includes a non-ASCII string.

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -130,7 +130,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
 
     # if we have a list, transform it into a string first
     if isinstance(address_list, list):
-        address_list = ', '.join([str(addr) for addr in address_list])
+        address_list = ', '.join(address_list)
 
     # parse
     try:

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -46,6 +46,19 @@ from flanker.mime.message.headers.encoding import encode_string
 from flanker.mime.message.headers.encodedword import mime_to_unicode
 from urlparse import urlparse
 
+
+def _normalize_address_list(address_list):
+    parts = []
+
+    for addr in address_list:
+        if isinstance(addr, Address):
+            parts.append(unicode(addr))
+        if isinstance(addr, basestring):
+            parts.append(addr)
+
+    return parts
+
+
 @metrics_wrapper()
 def parse(address, addr_spec_only=False, metrics=False):
     """
@@ -130,7 +143,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
 
     # if we have a list, transform it into a string first
     if isinstance(address_list, list):
-        address_list = ', '.join(address_list)
+        address_list = ', '.join(_normalize_address_list(address_list))
 
     # parse
     try:

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -114,6 +114,16 @@ def test_addresslist_non_ascii_list_input():
     eq_('Os Wi <oswi@example.com>', lst[1].full_spec())
 
 
+def test_addresslist_address_obj_list_input():
+    al = [EmailAddress(u'Aurélien Berger  <ab@example.com>'),
+          UrlAddress('https://www.example.com')]
+    lst = parse_list(al)
+    eq_(2, len(lst))
+    eq_('=?utf-8?q?Aur=C3=A9lien_Berger?= <ab@example.com>',
+        lst[0].full_spec())
+    eq_('https://www.example.com', lst[1].full_spec())
+
+
 def test_edge_cases():
     email = EmailAddress('"foo.bar@"@example.com')
     eq_('"foo.bar@"@example.com', email.address)

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -106,6 +106,14 @@ def test_addresslist_with_apostrophe():
     eq_(u'Eugueny ώ Kontsevoy', lst[0].display_name)
 
 
+def test_addresslist_non_ascii_list_input():
+    al = [u'Aurélien Berger  <ab@example.com>', 'Os Wi <oswi@example.com>']
+    lst = parse_list(al)
+    eq_(2, len(lst))
+    eq_('=?utf-8?q?Aur=C3=A9lien_Berger?= <ab@example.com>', lst[0].full_spec())
+    eq_('Os Wi <oswi@example.com>', lst[1].full_spec())
+
+
 def test_edge_cases():
     email = EmailAddress('"foo.bar@"@example.com')
     eq_('"foo.bar@"@example.com', email.address)


### PR DESCRIPTION
When decoding, addresslib shouldn't assume strings are only ASCII.

```
>>> from flanker.addresslib import address
>>> address.parse_list([u'A <\xfc@b.com>'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/flanker/utils.py", line 99, in wrapper
    return_value = f(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/flanker/addresslib/address.py", line 133, in parse_list
    address_list = ', '.join([str(addr) for addr in address_list])
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 3: ordinal not in range(128)
```

Discovered via https://github.com/inboxapp/inbox/issues/102