### PR TITLE
If unable to contact a host, don't cache that result.

### DIFF
--- a/flanker/addresslib/validate.py
+++ b/flanker/addresslib/validate.py
@@ -138,7 +138,6 @@ def mail_exchanger_lookup(domain, metrics=False):
         mx_hosts = lookup_domain(domain)
         mtimes['dns_lookup'] += time.time() - bstart
         if mx_hosts is None:
-            mx_cache[domain] = False
             return None, mtimes
 
     # test connecting to the mx exchanger
@@ -146,7 +145,6 @@ def mail_exchanger_lookup(domain, metrics=False):
     mail_exchanger = connect_to_mail_exchanger(mx_hosts)
     mtimes['mx_conn'] = time.time() - bstart
     if mail_exchanger is None:
-        mx_cache[domain] = False
         return None, mtimes
 
     # valid mx records, connected to mail exchanger, return True


### PR DESCRIPTION
**Purpose**

Right now, if we fail to connect to a MX server, we cache that as unable to connect. This can cause issues if the inability to connect was either a DNS timeout or some other temporary network issues. This commit changes this behavior to not cache the result of a MX lookup.

**Implementation**

In the function `mail_exchanger_lookup` in `validate.py` remove the lines that cache lookup values that were `False`.
