### PR TITLE
Don't throw an exception for .eml attachments with broken MIME.

### DIFF
--- a/flanker/mime/create.py
+++ b/flanker/mime/create.py
@@ -69,7 +69,7 @@ def attachment(content_type, body, filename=None,
             message.headers['Content-Disposition'] = WithParams(disposition)
             return message
         except DecodingError:
-            content_type = ContentType('text', 'plain')
+            content_type = ContentType('application', 'octet-stream')
     return binary(
         content_type.main,
         content_type.sub,


### PR DESCRIPTION
This function used to fail when creating an attachment that happened to
contain text with broken MIME. Now when that happens, we just encode it
and call the attachment type 'text/plain'.
