### PR TITLE
Fix handling for broken .eml messages.

### DIFF
--- a/flanker/mime/create.py
+++ b/flanker/mime/create.py
@@ -37,10 +37,11 @@ def text(subtype, body, charset=None, disposition=None, filename=None):
 
 
 def binary(maintype, subtype, body, filename=None,
-           disposition=None, charset=None):
+           disposition=None, charset=None, trust_ctype=False):
     return MimePart(
         container=Body(
             content_type=ContentType(maintype, subtype),
+            trust_ctype=trust_ctype,
             body=body,
             charset=charset,
             disposition=disposition,
@@ -75,7 +76,7 @@ def attachment(content_type, body, filename=None,
         content_type.sub,
         body, filename,
         disposition,
-        charset)
+        charset, True)
 
 
 def from_string(string):

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -137,7 +137,7 @@ def _guess_type(filename):
 
 class Body(object):
     def __init__(
-        self, content_type, body, charset=None, disposition=None, filename=None):
+        self, content_type, body, charset=None, disposition=None, filename=None, trust_ctype=False):
         self.headers = headers.MimeHeaders()
         self.body = body
         self.disposition = disposition or ('attachment' if filename else None)
@@ -147,7 +147,8 @@ class Body(object):
         if self.filename:
             self.filename = path.basename(self.filename)
 
-        content_type = adjust_content_type(content_type, body, filename)
+        if not trust_ctype:
+            content_type = adjust_content_type(content_type, body, filename)
 
         if content_type.main == 'text':
             # the text should have a charset

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -52,6 +52,8 @@ ENCLOSED_BROKEN_BODY = open(
     fixture_file("messages/enclosed-broken-body.eml")).read()
 ENCLOSED_BROKEN_ENCODING = open(
     fixture_file("messages/enclosed-bad-encoding.eml")).read()
+FALSE_MULTIPART = open(
+    fixture_file("messages/false-multipart.eml")).read()
 ENCODED_HEADER = open(
     fixture_file("messages/encoded-header.eml")).read()
 MESSAGE_EXTERNAL_BODY= open(

--- a/tests/fixtures/messages/false-multipart.eml
+++ b/tests/fixtures/messages/false-multipart.eml
@@ -1,0 +1,11 @@
+Content-Type: multipart/alternative;
+ boundary="9c1a8544d562472896bc53f5da3057c0"
+Mime-Version: 1.0
+Subject: Broken MIME
+From: Mime Breaker <broken.mime@notreallymultipart.com>
+To: example.smith@example.com
+Message-Id: <12345@example.com>
+
+
+
+

--- a/tests/mime/message/create_test.py
+++ b/tests/mime/message/create_test.py
@@ -261,6 +261,13 @@ def attaching_emails_test():
     eq_("message/rfc822", attachment.content_type)
 
 
+def attaching_broken_emails_test():
+    attachment = create.attachment(
+        "application/octet-stream", FALSE_MULTIPART, "message.eml", "attachment")
+    ok_(attachment.is_attachment())
+    eq_("application/octet-stream", attachment.content_type)
+
+
 def attaching_images_test():
     attachment = create.attachment(
         "application/octet-stream", MAILGUN_PNG, "/home/alex/mailgun.png")


### PR DESCRIPTION
I didn't test this well enough yesterday. It turns out that the
attachment was getting created, but its ContentType was overwritten to
message/rfc822. This caused problems elsewhere because the the
attachment we created did not have the structure expected for
message/rfc822.

The fix: Don't let Body override our ContentType declaration.