### PR TITLE
Override tricky content types.

### DIFF
--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -91,6 +91,12 @@ def adjust_content_type(content_type, body=None, filename=None):
     """Adjust content type based on filename or body contents
     """
     if filename and str(content_type) == 'application/octet-stream':
+        # check if our internal guess returns anything
+        guessed = _guess_type(filename)
+        if guessed:
+            return guessed
+
+        # our internal attempt didn't return anything, use mimetypes
         guessed = mimetypes.guess_type(filename)[0]
         if guessed:
             main, sub = fix_content_type(
@@ -108,6 +114,21 @@ def adjust_content_type(content_type, body=None, filename=None):
             content_type = ContentType('audio', sub)
 
     return content_type
+
+
+def _guess_type(filename):
+    """
+    Internal content type guesser. This is used to hard code certain tricky content-types
+    that heuristic content type checker get wrong.
+    """
+
+    if filename.endswith(".bz2"):
+        return ContentType("application", "x-bzip2")
+
+    if filename.endswith(".gz"):
+        return ContentType("application", "x-gzip")
+
+    return None
 
 
 class Body(object):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.26',
+      version='0.4.27',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,6 +64,7 @@ QUOTED_PRINTABLE = open(
     fixture_file("messages/quoted-printable.eml")).read()
 TEXT_ONLY = open(fixture_file("messages/text-only.eml")).read()
 MAILGUN_PIC = open(fixture_file("messages/mailgun-pic.eml")).read()
+BZ2_ATTACHMENT  = open(fixture_file("messages/bz2-attachment.eml")).read()
 
 AOL_FBL = open(fixture_file("messages/complaints/aol.eml")).read()
 YAHOO_FBL = open(fixture_file("messages/complaints/yahoo.eml")).read()

--- a/tests/fixtures/messages/bz2-attachment.eml
+++ b/tests/fixtures/messages/bz2-attachment.eml
@@ -1,0 +1,21 @@
+Content-Type: multipart/mixed; boundary="9ca4f9e3b740436bb761d3f9aae5fae9"
+Mime-Version: 1.0
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+Subject: hello
+
+--9ca4f9e3b740436bb761d3f9aae5fae9
+Mime-Version: 1.0
+Content-Type: text/plain; charset="ascii"
+Content-Transfer-Encoding: 7bit
+
+hello, world
+
+--9ca4f9e3b740436bb761d3f9aae5fae9
+Mime-Version: 1.0
+Content-Type: application/octet-stream; name="foo.txt.bz2"
+Content-Disposition: attachment; filename="foo.txt.bz2"
+Content-Transfer-Encoding: base64
+
+QlpoOTFBWSZTWQ0xSP4AAAFBgAAQMAAQACAAIZpoM00XPF3JFOFCQDTFI/g=
+--9ca4f9e3b740436bb761d3f9aae5fae9--

--- a/tests/mime/message/part_test.py
+++ b/tests/mime/message/part_test.py
@@ -9,7 +9,7 @@ from flanker.mime.create import multipart, text
 from flanker.mime.message.scanner import scan
 from flanker.mime.message.errors import EncodingError, DecodingError
 from flanker.mime.message.part import encode_transfer_encoding
-from tests import (BILINGUAL, ENCLOSED, TORTURE, TORTURE_PART,
+from tests import (BILINGUAL, BZ2_ATTACHMENT, ENCLOSED, TORTURE, TORTURE_PART,
                    ENCLOSED_BROKEN_ENCODING, EIGHT_BIT, QUOTED_PRINTABLE,
                    TEXT_ONLY, ENCLOSED_BROKEN_BODY, RUSSIAN_ATTACH_YAHOO,
                    MAILGUN_PIC, MAILGUN_PNG, MULTIPART, IPHONE,
@@ -387,6 +387,13 @@ def content_types_test():
     eq_('image/png', attachment.detected_content_type)
     eq_('png', attachment.detected_subtype)
     eq_('image', attachment.detected_format)
+    ok_(not attachment.is_body())
+
+    part = scan(BZ2_ATTACHMENT)
+    attachment = part.parts[1]
+    eq_('application/x-bzip2', attachment.detected_content_type)
+    eq_('x-bzip2', attachment.detected_subtype)
+    eq_('application', attachment.detected_format)
     ok_(not attachment.is_body())
 
 


### PR DESCRIPTION
**Purpose**

Some content types are tricky and hard for heuristic based content type discovery algorithms. For example, `bzip2` files typically retain their file extension, and content type discovery algorithms like the one in `mimetypes` mark `bzip2` filenames like `foo.txt.bz2` as `text/plain` because of the `.txt` in the filename.

This commit adds support for overriding the heuristic and for certain tricky filetypes, returning hard-coded values. This specific PR only adds support for `bzip2` and `gzip`

**Implementation**

* If the specific content type was not already discovered and simply marked as `application/octet-stream` then the function `adjust_content_type` in `part.py` first calls the internal  `_guess_type` to see if it can discover the content type based off the filename.
* `_guess_type` simply checks if the filename ends with `.bz2` or `.gz`, and if it does, returns the `ContentType` as `application/x-bzip2` or `application/x-gzip` respectively.
* A test has been added that verifies this change.
