### PR TITLE
fix bug with != operator against a string (#78)

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -427,6 +427,13 @@ class EmailAddress(Address):
             return self.address.lower() == other.address.lower()
         return False
 
+    def __ne__(self, other):
+        """
+        Negative comparison support
+        """
+        return not (self == other)
+
+
     def __hash__(self):
         """
         Hashing allows using Address objects as keys in collections and compare

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -46,6 +46,13 @@ def test_address_compare():
     s.add(u)
     eq_(2, len(s))
 
+    # test string comparison
+    ok_(a == a.address)
+    ok_(not (a != a.address))
+
+    ok_(b != a.address)
+    ok_(not (b == a.address))
+
 
 def test_local_url():
     u = UrlAddress('http:///foo/bar')


### PR DESCRIPTION
Added a little snippet (and a test) to deal with issue #78.  By
implementing `__ne__`, `email_address != str` behaves as expected.