### PR TITLE
Grab stream position from tell() if it's returned as None

### DIFF
--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -62,6 +62,8 @@ class Stream(object):
 
     def _load_headers(self):
         if self._headers is None:
+            if self.start is None:
+                self.start = self.stream.tell()
             self.stream.seek(self.start)
             self._headers = headers.MimeHeaders.from_stream(self.stream)
             self._body_start = self.stream.tell()


### PR DESCRIPTION
This can happen when there's an empty body, such as in the following message:

```
Delivered-To: khamidou@inboxapp.com
Date: 11 Jan 2013 18:54:26 -0000
MIME-Version: 1.0
To: <khamidou@inboxapp.com>
Message-ID: <1357884894.S.69618.18751.f5mail-224-118.example.com>
Sender: someone@example.com
Subject: Dear sir
From: "John Doe " <someone@example.com>
Content-Type: multipart/mixed;
    boundary="=_e6ddd3579a993208589b263b76d66bec"

--=_e6ddd3579a993208589b263b76d66bec
Content-Transfer-Encoding: 7bit
Content-Type: text/plain; charset="UTF-8"

URGENT - HELP ME DISTRIBUTE MY $15 MILLION TO CHARITY

IN SUMMARY:- I have 15,000,000.00 (fifteen million) U.S. Dollars and I want you to assist me in distributing the money to charity organizations.

--=_e6ddd3579a993208589b263b76d66bec
Content-Transfer-Encoding:
Content-Type: message/rfc822;
 name="ForwardedMessage";
Content-Disposition: inline;
 filename="ForwardedMessage";
```

Closes https://github.com/mailgun/flanker/issues/64