### PR TITLE
Reject consecutive dots (.) in gmail addresses

### DIFF
--- a/flanker/addresslib/validate.py
+++ b/flanker/addresslib/validate.py
@@ -86,11 +86,6 @@ def preparse_address(addr_spec):
     if len(parts) < 2:
         return None
 
-    # if we add more esp specific checks, they should be done
-    # with a dns lookup not string matching domain
-    if parts[1] == 'gmail.com' or parts[1] == 'googlemail.com':
-        parts[0] = parts[0].replace('.', '')
-
     return parts
 
 

--- a/tests/addresslib/plugins/gmail_test.py
+++ b/tests/addresslib/plugins/gmail_test.py
@@ -65,8 +65,8 @@ def test_gmail_pass():
             addr = address.validate_address(localpart + DOMAIN)
             assert_not_equal(addr, None)
 
-        # all dots (.) are ignored
-        for localpart in ['aaaaaa......', '......aaaaaa', 'aaa......aaa','aa...aa...aa']:
+        # non-consecutive dots (.) within an address are legal
+        for localpart in ['a.aaaaa', 'aa.aaaa', 'aaa.aaa','aa.aa.aa']:
             addr = address.validate_address(localpart + DOMAIN)
             assert_not_equal(addr, None)
 
@@ -106,8 +106,8 @@ def test_gmail_fail():
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)
 
-        # all dots (.) are ignored
-        for localpart in ['aaaaa......', '......aaaaa', 'aaa......aa','aa...a...aa']:
+        # invalid consecutive dots (.)
+        for localpart in ['aaaaaa......', '......aaaaaa', 'aaa......aaa','aa...aa...aa']:
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)
 


### PR DESCRIPTION
**Purpose**

Ordinarily, mail sent to Gmail addresses is stripped of dot (.) characters by the receiving Gmail mail server before being processed. This means Gmail will accept addresses that are syntactically incorrect according to the [RFC 5322 § 3.4.1](http://tools.ietf.org/html/rfc5322#section-3.4.1).

Flanker handles this by having two endpoints, `addresslib.address.parse()` which is strict-ish RFC grammar and `addresslib.address.validate_address()` which applies the RFC rules but also stricter per ESP custom grammar. This lead to odd behavior when we had the stricter API mark an address like `foo...bar@gmail.com` as valid, but the less strict RFC API mark it as invalid.

This seemed like a reasonable compromise at the time. However, based off user feedback, we have found that is a confusing result. If something is marked as valid by `validate_address()` it should also be considered valid by `parse()`. Also, if a user is submitting an address like `foo...bar..baz@gmail.com` is is most likely an invalid address anyway. After all, the user who knows that Gmail allows consecutive dots is going to be savvy enough (having run into this issue many times) to know that to have his adress marked as valid, they need to strip the dots.

This Pull Request seeks to align `validate_address()`'s behavior to be no more permissive than `parse()`, as the set of addresses validated by `validate_address()` is expected to be a subset of those validated by `parse()`. This is done by not permitting consecutive dots (`..`) in Gmail addresses and marking them as invalid.

**Implementation** 

Updated the Gmail plugin with the new grammar rules. Now dots (.) are not stripped before processing, but are processed as is, with a limit of not allowing consecutive dots encoded into the grammar itself.