### PR TITLE
work harder to avoid re-serializing headers

### DIFF
--- a/flanker/mime/message/headers/headers.py
+++ b/flanker/mime/message/headers/headers.py
@@ -34,8 +34,12 @@ class MimeHeaders(object):
         return normalize(key) in self._v
 
     def __setitem__(self, key, value):
-        self._v[normalize(key)] = remove_newlines(value)
-        self.changed = True
+        key = normalize(key)
+        if key in self._v:
+            self._v[key] = remove_newlines(value)
+            self.changed = True
+        else:
+            self.prepend(key, remove_newlines(value))
 
     def __delitem__(self, key):
         del self._v[normalize(key)]
@@ -51,9 +55,7 @@ class MimeHeaders(object):
     def add(self, key, value):
         """Adds header without changing the
         existing headers with same name"""
-
-        self._v.add(normalize(key), remove_newlines(value))
-        self.changed = True
+        self.prepend(key, value)
 
     def keys(self):
         """

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -76,8 +76,9 @@ class Stream(object):
                 self.stream.read(self.end - self._body_start + 1))
 
     def _set_body(self, value):
-        self._body = value
-        self._body_changed = True
+        if value != self._body:
+            self._body = value
+            self._body_changed = True
 
 
     def headers_changed(self, ignore_prepends=False):
@@ -479,7 +480,8 @@ class MimePart(RichPartMixin):
         """
         Serializes the message using a file like object.
         """
-        if not self.was_changed():
+        if not self.was_changed(ignore_prepends=True):
+            self.headers.to_stream(out, prepends_only=True)
             out.write(self._container.read_message())
         else:
             try:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.30',
+      version='0.4.31',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/mime/message/fallback/fallback_test.py
+++ b/tests/mime/message/fallback/fallback_test.py
@@ -227,8 +227,8 @@ def message_headers_mutation_test():
 
 def message_headers_append_test():
     """
-    `prepend` and `add` add a header to the beginning and the end of the header
-    list respectively.
+    `prepend` and `add` both insert a header at the beginning and the end of the
+    header list.
     """
     # Given
     orig = create.from_string(ENCLOSED)
@@ -239,8 +239,8 @@ def message_headers_append_test():
     restored = create.from_python(orig.to_python_message())
 
     # Then
-    eq_(('Foo-Bar', 'hello'), restored.headers.items()[0])
-    eq_(('Blah', 'kitty'), restored.headers.items()[-1])
+    eq_(('Blah', 'kitty'), restored.headers.items()[0])
+    eq_(('Foo-Bar', 'hello'), restored.headers.items()[1])
 
 
 def message_headers_transform_test():

--- a/tests/mime/message/headers/headers_test.py
+++ b/tests/mime/message/headers/headers_test.py
@@ -58,12 +58,12 @@ def headers_multiple_values_test():
     eq_(['5'], h.getall('Mime-Version'))
 
     # use add to add more values
-    h.add('Received', '6')
-    eq_(['2', '4', '6'], h.getall('Received'))
+    h.add('Received', '1')
+    eq_(['1', '2', '4'], h.getall('Received'))
 
     # use prepend to insert header in the begining of the list
     h.prepend('Received', '0')
-    eq_(['0', '2', '4', '6'], h.getall('Received'))
+    eq_(['0', '1', '2', '4'], h.getall('Received'))
 
     # delete removes it all!
     del h['RECEIVED']

--- a/tests/mime/message/scanner_test.py
+++ b/tests/mime/message/scanner_test.py
@@ -112,7 +112,7 @@ def mailbox_full_test():
 def test_uservoice_case():
     message = scan(LONG_LINKS)
     html = message.body
-    message.body = html
+    message._container._body_changed = True
     val = message.to_string()
     for line in val.splitlines():
         print line


### PR DESCRIPTION
**Purpose**

We want to avoid re-serializing parsed messages, for two reasons:

1. It's slow. We already have the original text, so if we can output it
   as-is we save a bunch of work.
2. It canonicalizes headers. This can break DKIM signatures, which hurts
   deliverability.

**Implementation**

This commit does three things:

1. `message.headers["some-header"] = "some value"` now causes a prepend
   if "some-header" is not present in the message yet. Prepends are
   better than arbitrary insertions, because they do not force us to
   re-serialize the rest of the message.
2. `message.headers.add("some-header, "some value")` now causes a
   prepend, for the same reason as 1. This previously added the header
   at the end of the list instead. I am assuming this behavior change is OK.
3. `message.body = message.body` no longer causes the message to be
   marked as changed.

Related commit: 9c89b875dc0eafc01c7f9725d5db5aff8f798f70