### PR TITLE
fix exception in serialization of messages with malformed headers

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -65,6 +65,7 @@ QUOTED_PRINTABLE = open(
 TEXT_ONLY = open(fixture_file("messages/text-only.eml")).read()
 MAILGUN_PIC = open(fixture_file("messages/mailgun-pic.eml")).read()
 BZ2_ATTACHMENT  = open(fixture_file("messages/bz2-attachment.eml")).read()
+OUTLOOK_EXPRESS = open(fixture_file("messages/outlook-express.eml")).read()
 
 AOL_FBL = open(fixture_file("messages/complaints/aol.eml")).read()
 YAHOO_FBL = open(fixture_file("messages/complaints/yahoo.eml")).read()

--- a/tests/fixtures/messages/outlook-express.eml
+++ b/tests/fixtures/messages/outlook-express.eml
@@ -1,0 +1,28 @@
+X-Envelope-From: <bob@example.com>
+Received: from hwmail1.mailset.cn (hwmail1.mailset.cn [106.186.124.194]) by
+ mxa.mailgun.org with ESMTP id 53c3560e.7fe658457ed8-in3; Mon, 14 Jul 2014
+ 04:01:18 -0000 (UTC)
+Received: (ce send program); Mon, 14 Jul 2014 12:01:03 +0800
+Received: from 121.14.7.230 (HELO etcsmtp.xinnetdns.com) (121.14.7.230) by
+ 106.186.124.194 with SMTP; Mon, 14 Jul 2014 12:01:03 +0800
+Received: (ce send program); Mon, 14 Jul 2014 11:49:09 +0800
+X-Ce-Autoforward: etcsmtp.xinnetdns.com
+Message-Id: <EFOOJNZYKZFPXKXDZPRSCFMBVCHB.bob@example.com>
+Received: (ce send program); Mon, 14 Jul 2014 11:49:07 +0800
+Received: from 123.100.1.157 (HELO sink-gdmm.com) (123.100.1.157) by
+ 121.14.68.74 with SMTP; Mon, 14 Jul 2014 11:49:07 +0800
+Return-Path: <bob@example.com>
+Received: from [110.230.143.217] by 121.14.68.114 with surfront esmtp id
+ 9885528886420;	Mon, 14 Jul 2014 12:00:56 +0800 (CST)
+From: Bobby <bob@example.com>
+Subject: Sup?
+To: "Ally" <ally@example.com>
+Content-Type: application/octet-stream;
+        name="�½� �ı��ĵ�.txt"
+Content-Transfer-Encoding: base64
+Mime-Version: 1.0
+Date: Tue, 14 Jul 2015 12:19:08 +0800
+X-Mailer: Microsoft Outlook Express 6.00.2800.1106
+X-Mailgun-Incoming: Yes
+
+0YLQtdC60YHRgtC+0LLQvtC1INCy0LvQvtC20LXQvdC40LU=

--- a/tests/mime/message/part_test.py
+++ b/tests/mime/message/part_test.py
@@ -14,7 +14,7 @@ from tests import (BILINGUAL, BZ2_ATTACHMENT, ENCLOSED, TORTURE, TORTURE_PART,
                    TEXT_ONLY, ENCLOSED_BROKEN_BODY, RUSSIAN_ATTACH_YAHOO,
                    MAILGUN_PIC, MAILGUN_PNG, MULTIPART, IPHONE,
                    SPAM_BROKEN_CTYPE, BOUNCE, NDN, NO_CTYPE, RELATIVE,
-                   MULTI_RECEIVED_HEADERS)
+                   MULTI_RECEIVED_HEADERS, OUTLOOK_EXPRESS)
 from tests.mime.message.scanner_test import TORTURE_PARTS, tree_to_string
 
 
@@ -234,6 +234,16 @@ def preserve_formatting_with_new_headers_test():
     new_header, remaining_mime = message.to_string().split('\r\n', 1)
     eq_('X-New-Header: Added', new_header)
     eq_(MULTIPART, remaining_mime)
+
+
+def parse_then_serialize_malformed_message_test():
+    """
+    We don't have to fully parse message headers if they are never accessed.
+    Thus we should be able to parse then serialize a message with malformed
+    headers without crashing, even though we would crash if we fully parsed it.
+    """
+    serialized = scan(OUTLOOK_EXPRESS).to_string()
+    eq_(OUTLOOK_EXPRESS, serialized)
 
 
 def ascii_to_unicode_test():


### PR DESCRIPTION
flanker.mime.create.from_string does not fully parse message headers.
Instead, headers are parsed lazily the first time they are accessed. So
even though flanker.mime.create.from_string does not support malformed
headers, this isn't a problem if they are never accessed.

Commits 9c89b875dc0eafc01c7f9725d5db5aff8f798f70 and
cd271929bf831999c40e616da3dfacd3694eae56 caused headers to be accessed
every time a message is serialized. This made it impossible to parse and
then re-serialize a message with broken headers, even though this used
to be possible if the headers were never accessed after parsing.

This commit brings back that option: it is again possible to parse and
then re-serialize a message with broken headers.