### PR TITLE
Allow star characters in the type or subtype of a Content-Type header

### DIFF
--- a/flanker/mime/message/headers/parametrized.py
+++ b/flanker/mime/message/headers/parametrized.py
@@ -246,7 +246,7 @@ headerValue = re.compile(r"""
        # don't care about the spaces
        ^[\ \t]*
        #main type and sub type or any other value
-       ([a-z0-9\-/\.]+)
+       ([a-z0-9\-/\.\*]+)
        # grab the trailing spaces, colons
        [\ \t;]*""", re.IGNORECASE | re.VERBOSE)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.34',
+      version='0.4.35',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/mime/message/headers/parsing_test.py
+++ b/tests/mime/message/headers/parsing_test.py
@@ -1,0 +1,7 @@
+from nose.tools import *
+
+from flanker.mime.message.headers import parsing
+
+def test_content_type_star():
+    _, ctype = parsing.parse_header('Content-Type: image/* ; name="Stuart *Wells.PNG"')
+    eq_(ctype.value, 'image/*')


### PR DESCRIPTION
RFC 1521 does not disallow star characters in the type or subtype of a
Content-Type header.