### PR TITLE
Sergey/is body

### DIFF
--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -284,7 +284,8 @@ class RichPartMixin(object):
                                    filename=self.detected_file_name)
 
     def is_body(self):
-        return (not self.detected_file_name and
+        return (not self.is_attachment() and
+                not self.detected_file_name and
                 (self.content_type.format_type == 'text' or
                  self.content_type.format_type == 'message'))
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -38,6 +38,7 @@ TORTURE_PART = open(fixture_file("messages/torture-part.eml")).read()
 BILINGUAL = open(fixture_file("messages/bilingual-simple.eml")).read()
 RELATIVE = open(fixture_file("messages/relative.eml")).read()
 IPHONE = open(fixture_file("messages/iphone.eml")).read()
+NO_FILENAME = open(fixture_file("messages/no-filename.eml")).read()
 
 MULTIPART = open(fixture_file("messages/multipart.eml")).read()
 FROM_ENCODING = open(fixture_file("messages/from-encoding.eml")).read()

--- a/tests/fixtures/messages/no-filename.eml
+++ b/tests/fixtures/messages/no-filename.eml
@@ -1,0 +1,49 @@
+From: Joe Smith <joe.smith@example.com>
+To: "to@example.com" <to@example.com>
+Subject: Test attachment eml
+Content-Type: multipart/mixed;
+	boundary="_004_D1DD52AF13485joesmithEXAMPLECOM_"
+
+--_004_D1DD52AF13485joesmithEXAMPLECOM_
+Content-Type: multipart/alternative;
+	boundary="_000_D1DD52AF13485joesmithEXAMPLECOM_"
+
+--_000_D1DD52AF13485joesmithEXAMPLECOM_
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+Test
+
+--_000_D1DD52AF13485joesmithEXAMPLECOM_
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dus-ascii"=
+>
+</head>
+<body style=3D"word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-lin=
+e-break: after-white-space; color: rgb(0, 0, 0); font-size: 14px; font-fami=
+ly: Calibri, sans-serif;">
+<div>Test</div>
+</body>
+</html>
+
+--_000_D1DD52AF13485joesmithEXAMPLECOM_--
+
+--_004_D1DD52AF13485joesmithEXAMPLECOM_
+Content-Type: message/rfc822
+Content-Disposition: attachment;
+	creation-date="Tue, 28 Jul 2015 20:39:30 GMT";
+	modification-date="Tue, 28 Jul 2015 20:39:30 GMT"
+Content-ID: <6DF578E1987984448F8796FBAFEAFB14@example.com>
+
+Content-Type: text/plain
+MIME-Version: 1.0
+
+Subject:Hi
+
+Hello
+
+--_004_D1DD52AF13485joesmithEXAMPLECOM_--

--- a/tests/mime/message/part_test.py
+++ b/tests/mime/message/part_test.py
@@ -14,7 +14,7 @@ from tests import (BILINGUAL, BZ2_ATTACHMENT, ENCLOSED, TORTURE, TORTURE_PART,
                    TEXT_ONLY, ENCLOSED_BROKEN_BODY, RUSSIAN_ATTACH_YAHOO,
                    MAILGUN_PIC, MAILGUN_PNG, MULTIPART, IPHONE,
                    SPAM_BROKEN_CTYPE, BOUNCE, NDN, NO_CTYPE, RELATIVE,
-                   MULTI_RECEIVED_HEADERS)
+                   MULTI_RECEIVED_HEADERS, NO_FILENAME)
 from tests.mime.message.scanner_test import TORTURE_PARTS, tree_to_string
 
 
@@ -400,6 +400,14 @@ def content_types_test():
 def test_is_body():
     part = scan(IPHONE)
     ok_(part.parts[0].is_body())
+
+
+def test_attachment_without_filename_not_body():
+    part = scan(NO_FILENAME)
+    disposition, params = part.parts[1].content_disposition
+    eq_(disposition, 'attachment')
+    assert_false('filename' in params)
+    assert_false(part.parts[1].is_body())
 
 
 def message_attached_test():


### PR DESCRIPTION
MS Outlook when attaching ``message/rfc822`` doesn't provide a ``filename`` parameter for this attachment:

```
--_004_D1DD52AF13485_
Content-Type: message/rfc822
Content-Disposition: attachment;
    creation-date="Tue, 28 Jul 2015 20:39:30 GMT";
    modification-date="Tue, 28 Jul 2015 20:39:30 GMT"
Content-ID: <6DF578E1987984448F8796FBAFEAFB14@example.com>

Content-Type: text/plain
MIME-Version: 1.0

...
```

so flanker considers it to be a body of a message and doesn't recognize as attachment.

But according to [RFC](https://www.ietf.org/rfc/rfc2183.txt) ``filename`` parameter isn't required for attachments:

```
   In the extended BNF notation of [RFC 822], the Content-Disposition
   header field is defined as follows:

     disposition := "Content-Disposition" ":"
                    disposition-type
                    *(";" disposition-parm)

     disposition-type := "inline"
                       / "attachment"
                       / extension-token
                       ; values are not case-sensitive

     disposition-parm := filename-parm
                       / creation-date-parm
                       / modification-date-parm
                       / read-date-parm
                       / size-parm
                       / parameter
```