### PR TITLE
Return short message when getting string representation errors

### DIFF
--- a/flanker/mime/message/errors.py
+++ b/flanker/mime/message/errors.py
@@ -4,9 +4,13 @@ class MimeError(Exception):
 
 class DecodingError(MimeError):
     """Thrown when there is an encoding error."""
-    pass
+
+    def __str__(self):
+        return self.message[:256]
 
 
 class EncodingError(MimeError):
     """Thrown when there is an decoding error."""
-    pass
+
+    def __str__(self):
+        return self.message[:256]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.38',
+      version='0.4.39',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],


### PR DESCRIPTION
**Purpose**

Right now the string representation of a `DecodingError` or `EncodingError` can contain the entire MIME message. For example, [this can happen when converting to UTF-8](https://github.com/mailgun/flanker/blob/1831da20f19186ec248daa4e3c178510c752ce0d/flanker/utils.py#L42). This can cause problems when logging messages.

This PR returns a truncated version of that entire message so that the string representation of an `DecodingError` or `EncodingError` can be logged safely but still allows you to access the entire exception when needed.

**Implementation**

Truncate the message returned to 256 characters in `__str__`.