### PR TITLE
Adding a parameter to avoid to connection to mx

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -152,7 +152,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
 
 
 @metrics_wrapper()
-def validate_address(addr_spec, metrics=False):
+def validate_address(addr_spec, metrics=False, mx_lookup=True):
     """
     Given an addr-spec, runs the pre-parser, the parser, DNS MX checks,
     MX existence checks, and if available, ESP specific grammar for the
@@ -192,9 +192,15 @@ def validate_address(addr_spec, metrics=False):
     if paddr is None:
         return None, mtimes
 
+    # Here, we can set an option to discover MX from DNS, but not connect
+    # it is more fast
+    connect_to_mx = True
+    if not mx_lookup:
+        connect_to_mx = False
+
     # lookup if this domain has a mail exchanger
     exchanger, mx_metrics = \
-        flanker.addresslib.validate.mail_exchanger_lookup(addr_parts[-1], metrics=True)
+        flanker.addresslib.validate.mail_exchanger_lookup(addr_parts[-1], metrics=True, connect_to_mx=connect_to_mx)
     mtimes['mx_lookup'] = mx_metrics['mx_lookup']
     mtimes['dns_lookup'] = mx_metrics['dns_lookup']
     mtimes['mx_conn'] = mx_metrics['mx_conn']

--- a/flanker/addresslib/validate.py
+++ b/flanker/addresslib/validate.py
@@ -107,7 +107,7 @@ def plugin_for_esp(mail_exchanger):
 
 
 @metrics_wrapper()
-def mail_exchanger_lookup(domain, metrics=False):
+def mail_exchanger_lookup(domain, metrics=False, connect_to_mx=True):
     """
     Looks up the mail exchanger for a domain. If MX records exist they will
     be returned, if not it will attempt to fallback to A records, if neither
@@ -135,12 +135,15 @@ def mail_exchanger_lookup(domain, metrics=False):
         if mx_hosts is None:
             return None, mtimes
 
-    # test connecting to the mx exchanger
-    bstart = time.time()
-    mail_exchanger = connect_to_mail_exchanger(mx_hosts)
-    mtimes['mx_conn'] = time.time() - bstart
-    if mail_exchanger is None:
-        return None, mtimes
+    if connect_to_mx:
+        # test connecting to the mx exchanger
+        bstart = time.time()
+        mail_exchanger = connect_to_mail_exchanger(mx_hosts)
+        mtimes['mx_conn'] = time.time() - bstart
+        if mail_exchanger is None:
+            return None, mtimes
+    else:
+        mail_exchanger = mx_hosts[0]
 
     # valid mx records, connected to mail exchanger, return True
     mx_cache[domain] = mail_exchanger


### PR DESCRIPTION
I would like to add a feature to no connect to mx to process more faster in some cases that the service check is not needed.