### PR TITLE
Decode to UTF-8 before logging

### DIFF
--- a/flanker/mime/message/headers/encodedword.py
+++ b/flanker/mime/message/headers/encodedword.py
@@ -74,9 +74,14 @@ def mime_to_unicode(header):
         return u"".join(decoded)
     except Exception:
         try:
+            logged_header = header
+            if isinstance(logged_header, unicode):
+                logged_header = logged_header.encode('utf-8')
+                # encode header as utf-8 so all characters can be base64 encoded
+            logged_header = b64encode(logged_header)
             log.warning(
                 u"HEADER-DECODE-FAIL: ({0}) - b64encoded".format(
-                    b64encode(header)))
+                    logged_header))
         except Exception:
             log.exception("Failed to log exception")
         return header

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.39',
+      version='0.4.40',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],


### PR DESCRIPTION
This fixes an exception where a header contains a character that cannot be converted to ASCII, e.g. 0xea. Python will attempt to unicode strings to ascii before passing them to b64encode (which passes it to the internal C function binascii.b2a_b64). This commit forces encoding of the string as UTF-8, which contains no characters that cannot be encoded.

Solves https://github.com/mailgun/flanker/issues/117