### PR TITLE
Make DecodingError message safe

### DIFF
--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -1,6 +1,4 @@
-import regex as re
-from flanker.mime.message import errors
-from flanker.utils import to_utf8, to_unicode
+from flanker.utils import to_unicode
 
 
 def convert_to_unicode(charset, value):
@@ -9,7 +7,6 @@ def convert_to_unicode(charset, value):
         return value
 
     charset = _translate_charset(charset)
-
     return to_unicode(value, charset=charset)
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.40',
+      version='0.4.41',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],


### PR DESCRIPTION
When `_guess_and_convert_with` could not detect encoding of a value string it was generating `DecodingError` exception putting the value to the error message. But in some cases that can result in an exception deep inside the standard python logger implementation due to unicode encoding issue. Besides there is no reasonable cap on the size of the converted value. So it is better not to put it in the error message.