### PR TITLE
encode/decode enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.so
 
 # Packages
-*.egg
+*.eggs
 *.egg-info
 dist
 build
@@ -18,6 +18,7 @@ develop-eggs
 lib
 lib64
 __pycache__
+/ENV
 
 # Installer logs
 pip-log.txt

--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -26,6 +26,15 @@ def _translate_charset(charset):
     if 'koi8-r' in charset.lower():
         return 'koi8_r'
 
+    if 'gb2312' in charset.lower():
+        return 'gb2312'
+
+    if 'gb18030' in charset.lower():
+        return 'gb18030'
+
+    if 'gbk' in charset.lower():
+        return 'gbk'
+
     if 'utf-8' in charset.lower() or charset.lower() == 'x-unknown':
         return 'utf-8'
 

--- a/flanker/mime/message/errors.py
+++ b/flanker/mime/message/errors.py
@@ -14,3 +14,8 @@ class EncodingError(MimeError):
 
     def __str__(self):
         return self.message[:256]
+
+class DecodingDataCorruptionError(MimeError):
+
+    def __str__(self):
+        return self.message[:256]

--- a/flanker/mime/message/headers/encodedword.py
+++ b/flanker/mime/message/headers/encodedword.py
@@ -49,6 +49,10 @@ def mime_to_unicode(header, mimepart_charset=None):
     try:
         header = unfold(header)
         decoded = []  # decoded parts
+
+        acc_str = ''
+        acc_str_charset = None
+        acc_str_encoding = None
         while header:
             match = encodedWord.search(header)
             print match
@@ -58,19 +62,44 @@ def mime_to_unicode(header, mimepart_charset=None):
                     # decodes unencoded ascii part to unicode
                     value = charsets.convert_to_unicode(ascii, header[0:start])
                     if value.strip():
+                        if acc_str:
+                            raise errors.DecodingDataCorruptionError()
+
                         decoded.append(value)
+
                 # decode a header =?...?= of encoding
+                if (acc_str_charset is not None and acc_str_charset != match.group('charset').lower()) or \
+                    (acc_str_encoding is not None and acc_str_encoding != match.group('encoding').lower()):
+                        raise errors.DecodingDataCorruptionError()
                 charset, value = decode_part(
                     match.group('charset').lower() if match.group('charset') else mimepart_charset,
                     match.group('encoding').lower(),
-                    match.group('encoded'))
-                decoded.append(charsets.convert_to_unicode(charset, value))
+                    acc_str+match.group('encoded') if len(acc_str) > 0 else match.group('encoded'))
+                try:
+                    decode_str = charsets.convert_to_unicode(charset, value)
+                except errors.DecodingDataCorruptionError as e:
+                    acc_str += match.group('encoded')
+                    acc_str_charset = match.group('charset').lower()
+                    acc_str_encoding = match.group('encoding').lower()
+                    header = header[match.end():]
+                    continue
+
+                acc_str = ''
+                acc_str_charset = None
+                acc_str_encoding = None
+                decoded.append(decode_str)
                 header = header[match.end():]
             else:
                 # no match? append the remainder
                 # of the string to the list of chunks
+                if acc_str:
+                    raise errors.DecodingDataCorruptionError()
                 decoded.append(charsets.convert_to_unicode(ascii, header))
                 break
+
+        if acc_str:
+            raise errors.DecodingDataCorruptionError()
+
         return u"".join(decoded)
     except Exception:
         try:
@@ -86,6 +115,12 @@ def mime_to_unicode(header, mimepart_charset=None):
             log.exception("Failed to log exception")
         return header
 
+def decode_acc_str(acc_str, acc_charset, encoding):
+    charset, value = decode_part(acc_charset, encoding, acc_str)
+    acc_str = ''
+    acc_charset = None
+    encoding = None
+    return charsets.convert_to_unicode(charset, value)
 
 ascii = 'ascii'
 

--- a/flanker/mime/message/headers/encodedword.py
+++ b/flanker/mime/message/headers/encodedword.py
@@ -25,11 +25,11 @@ def unfold(value):
     return re.sub(foldingWhiteSpace, r"\2", value)
 
 
-def decode(header):
-    return mime_to_unicode(header)
+def decode(header, mimepart_charset=None):
+    return mime_to_unicode(header, mimepart_charset)
 
 
-def mime_to_unicode(header):
+def mime_to_unicode(header, mimepart_charset=None):
     """
     Takes a header value and returns a fully decoded unicode string.
     It differs from standard Python's mail.header.decode_header() because:
@@ -49,9 +49,9 @@ def mime_to_unicode(header):
     try:
         header = unfold(header)
         decoded = []  # decoded parts
-
         while header:
             match = encodedWord.search(header)
+            print match
             if match:
                 start = match.start()
                 if start != 0:
@@ -61,7 +61,7 @@ def mime_to_unicode(header):
                         decoded.append(value)
                 # decode a header =?...?= of encoding
                 charset, value = decode_part(
-                    match.group('charset').lower(),
+                    match.group('charset').lower() if match.group('charset') else mimepart_charset,
                     match.group('encoding').lower(),
                     match.group('encoded'))
                 decoded.append(charsets.convert_to_unicode(charset, value))

--- a/flanker/mime/message/headers/headers.py
+++ b/flanker/mime/message/headers/headers.py
@@ -132,12 +132,12 @@ class MimeHeaders(object):
         return str(self._v)
 
     @classmethod
-    def from_stream(cls, stream):
+    def from_stream(cls, stream, charset=None):
         """
         Takes a stream and reads the headers, decodes headers to unicode dict
         like object.
         """
-        return cls(parse_stream(stream))
+        return cls(parse_stream(stream, charset))
 
     def to_stream(self, stream, prepends_only=False):
         """

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -13,29 +13,29 @@ def normalize(header):
     return string.capwords(header.lower(), '-')
 
 
-def parse_stream(stream):
+def parse_stream(stream, charset=None):
     """Reads the incoming stream and returns list of tuples"""
     out = deque()
     for header in unfold(split(stream)):
-        out.append(parse_header(header))
+        out.append(parse_header(header, charset))
     return out
 
 
-def parse_header(header):
+def parse_header(header, charset=None):
     """ Accepts a raw header with name, colons and newlines
     and returns it's parsed value
     """
     name, val = split2(header)
     if not is_pure_ascii(name):
         raise DecodingError("Non-ascii header name")
-    return name, parse_header_value(name, encodedword.unfold(val))
+    return name, parse_header_value(name, encodedword.unfold(val), charset)
 
 
-def parse_header_value(name, val):
+def parse_header_value(name, val, charset=None):
     if not is_pure_ascii(val):
         if parametrized.is_parametrized(name, val):
             raise DecodingError("Unsupported value in content- header")
-        return to_unicode(val)
+        return to_unicode(val, charset)
     else:
         if parametrized.is_parametrized(name, val):
             val, params = parametrized.decode(val)

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -63,7 +63,7 @@ class Stream(object):
     def _load_headers(self):
         if self._headers is None:
             self.stream.seek(self.start)
-            self._headers = headers.MimeHeaders.from_stream(self.stream)
+            self._headers = headers.MimeHeaders.from_stream(self.stream, self.content_type.get_charset())
             self._body_start = self.stream.tell()
 
     def _load_body(self):

--- a/flanker/utils.py
+++ b/flanker/utils.py
@@ -52,9 +52,14 @@ def _make_unicode(value, charset=None):
     charset = charset or "utf-8"
     try:
         value = value.decode(charset, "strict")
-    except (UnicodeError, LookupError):
-        value = _guess_and_convert(value)
+    except UnicodeError as e:
+        print e.reason
+        if e.reason == "unexpected end of data":
+            raise errors.DecodingDataCorruptionError()
 
+        value = _guess_and_convert(value)
+    except LookupError as e:
+        value = _guess_and_convert(value)
     return value
 
 

--- a/flanker/utils.py
+++ b/flanker/utils.py
@@ -37,6 +37,7 @@ def _guess_and_convert_with(value, detector=cchardet):
         raise errors.DecodingError("Failed to guess encoding")
 
     try:
+        print 'decode by guesss '+ charset["encoding"]
         value = value.decode(charset["encoding"], "replace")
         return value
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -97,7 +97,7 @@ LONG_HEADER = open(
     fixture_file("messages/long-header.eml")).read()
 ATTACHED_PDF = open(fixture_file("messages/attached-pdf.eml")).read()
 
-
+CHARSET_GB2312 = open(fixture_file("messages/charset-gb2312.eml")).read()
 
 # addresslib fixture files
 MAILBOX_VALID_TESTS = open(fixture_file("mailbox_valid.txt")).read()

--- a/tests/fixtures/messages/charset-gb2312.eml
+++ b/tests/fixtures/messages/charset-gb2312.eml
@@ -1,0 +1,34 @@
+From: "腾讯企业邮箱" <10000@qq.com>
+Subject: 提示：您的企业成员暂时无法登录邮件客户端
+X-QQ-STYLE: 1
+Mime-Version: 1.0
+Content-Type: text/html;
+	charset="gb2312"
+Content-Transfer-Encoding: 7bit
+
+<div style="background:#ececec;padding:35px;">
+	<table cellpadding="0" align="center" width="600" style="background:#fff;width:600px;margin:0 auto;text-align:left;position:relative;border-radius:5px;font-size:14px; font-family:'lucida Grande',Verdana;line-height:1.5;box-shadow:0 0 5px #999999;border-collapse:collapse;">
+	<tr><th valign="middle" style="height:25px;color:#fff; font-size:14px;line-height:25px; font-weight:bold;text-align:left;padding:15px 35px; border-bottom:1px solid #467ec3;background:#518bcb;border-radius:5px 5px 0 0;">
+		<img style="float:left;" src="http://service.mail.qq.com/images/faq/bizmail_logo_01.gif"/>
+	</th></tr>
+	<tr><td>
+		<div style="padding:35px 35px 40px;">	
+			<h2 style="font-weight:bold; font-size:14px;margin:5px 0;">尊敬的管理员：</h2>
+			<p style="color:#313131;line-height:28px;font-size:14px;margin:20px 0;text-indent:2em;">系统检测到邮箱账号jianxin@jianxinapp.com频繁地登录失败，原因是密码错误。出于安全考虑，此邮箱账号暂时不能通过客户端使用企业邮箱。建议检查是否有多人或多台电脑设置了错误的密码。</p>
+			<p style="color:#313131;line-height:28px;font-size:14px;margin:20px 0;text-indent:2em;">此邮箱账号可以通过以下方法继续使用邮箱：</p>
+			<ul>
+				<li>使用腾讯企业邮箱的网页版</li>
+				<li>或在腾讯企业邮箱的网页版的“账号”设置里，开通微信动态密码，并为客户端增加授权密码。<a href="http://service.exmail.qq.com/cgi-bin/help?subtype=1&&no=1001023&&id=23">了解更多</a></li>
+			</ul>
+			</br>
+			<p style="color:#999; margin:26px 0 0 0; font-size:12px;">
+			腾讯企业邮箱门户：<a href="http://exmail.qq.com" target="_blank" style="color:#999;">http://exmail.qq.com</a><br>
+			企业邮箱帮助中心：<a href="http://service.exmail.qq.com" target="_blank" style="color:#999;">http://service.exmail.qq.com</a>
+			<span style="background:#ddd;height:1px;width:100%;overflow:hidden;display:block;margin:8px 0;"></span>
+			腾讯企业邮箱团队<br>
+			</p>
+		</div>
+	</td></tr>
+	</table>
+</div>
+

--- a/tests/mime/message/headers/encodedword_test.py
+++ b/tests/mime/message/headers/encodedword_test.py
@@ -116,6 +116,9 @@ def various_encodings_test():
     v = '"=?utf-8?b?6ICD5Y+W5YiG5Lqr?=" <foo@example.com>'
     eq_(u'"考取分享" <foo@example.com>', encodedword.mime_to_unicode(v))
 
+    v = '=?utf-8?Q?=e7=99=be=e5=ba=a6=e5=bc=80=e5=8f=91=e8=80=85=e5=b9=b3=e5=8f?=\n =?utf-8?Q?=b0?= <app_notice@baidu.com>'
+    eq_(u'百度开发者平台 <app_notice@baidu.com>', encodedword.mime_to_unicode(v))
+
     v = """=?UTF-8?B?0JbQtdC60LA=?= <ev@mailgun.net>, =?UTF-8?B?0JrQvtC90YbQtdCy0L7QuQ==?= <eugueny@gmail.com>"""
     eq_(u"Жека <ev@mailgun.net>, Концевой <eugueny@gmail.com>", encodedword.mime_to_unicode(v))
 

--- a/tests/mime/message/headers/encoding_test.py
+++ b/tests/mime/message/headers/encoding_test.py
@@ -97,6 +97,5 @@ def gb2312_encoding_test():
     subject = u'提示：您的企业成员暂时无法登录邮件客户端'
     from_addr = u'"腾讯企业邮箱" <10000@qq.com>'
 
-    print message.subject
     eq_(message.subject, subject)
     eq_(message.headers.getraw('from'), from_addr)

--- a/tests/mime/message/headers/encoding_test.py
+++ b/tests/mime/message/headers/encoding_test.py
@@ -10,7 +10,8 @@ from flanker.mime.message.headers.encoding import (encode_unstructured,
                                                    encode_string)
 from flanker.mime.message import part
 from flanker.mime import create
-from tests import LONG_HEADER, ENCODED_HEADER
+from flanker import mime
+from tests import LONG_HEADER, ENCODED_HEADER, CHARSET_GB2312
 
 
 def encodings_test():
@@ -44,7 +45,7 @@ def string_maxlinelen_test():
         encode_string(None, "very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong", maxlinelen=78))
 
 
-@patch.object(part.MimePart, 'was_changed', Mock(return_value=True))        
+@patch.object(part.MimePart, 'was_changed', Mock(return_value=True))
 def max_header_length_test():
     message = create.from_string(LONG_HEADER)
 
@@ -89,3 +90,13 @@ def add_header_preserve_original_encoding_test():
 
     # check original encoded header is still in the mime string
     ok_(original_from in message.to_string())
+
+def gb2312_encoding_test():
+    message = create.from_string(CHARSET_GB2312)
+
+    subject = u'提示：您的企业成员暂时无法登录邮件客户端'
+    from_addr = u'"腾讯企业邮箱" <10000@qq.com>'
+
+    print message.subject
+    eq_(message.subject, subject)
+    eq_(message.headers.getraw('from'), from_addr)


### PR DESCRIPTION
Fix 3 encoding/decoding problems during my daily usage of flanker, tests case from real life added

1. poor support of Chinese encoding including 'gb2312', 'gbk' and 'gb18030'

2. heavily rely on `_guess_and_convert`, ignore context-type as demonstrated by test email `charset-gb2312.eml`

3. cant handle encode word data corruption caused by encode word separation into multi lines as demonstrated by test case `encodedword_test `

