### PR TITLE
Ajay/qp encoding cleanup

### DIFF
--- a/flanker/metrics.py
+++ b/flanker/metrics.py
@@ -1,0 +1,53 @@
+
+import logging
+import os
+import time
+from contextlib import contextmanager
+
+_client = None
+_log = logging.getLogger(__name__)
+
+
+def init():
+    global _client
+
+    statsd_host = os.environ.get('FLANKER_METRICS_HOST')
+    statsd_port = os.environ.get('FLANKER_METRICS_PORT')
+    statsd_prfx = os.environ.get('FLANKER_METRICS_PREFIX')
+
+    if not statsd_host or not statsd_port or not statsd_prfx:
+        return
+
+    try:
+        import statsd
+    except ImportError:
+        return
+
+    _client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prfx)
+
+
+def incr(key, increment=1):
+    global _client
+    if _client:
+        if increment < 0:
+            _client.decr(key, increment)
+        else:
+            _client.incr(key, increment)
+    else:
+        # This hacky way of trying to initialize client, because flanker
+        # gets imported way before the application has a chance to set the
+        # environment variables for metrics.
+        if _client is None:
+            _client = False
+            init()
+            incr(key, increment)
+
+
+@contextmanager
+def timer(metric_name):
+    if _client:
+        t = time.time()
+        yield
+        _client.timing(metric_name, (time.time() - t) * 1000, 1)
+    else:
+        yield

--- a/flanker/utils.py
+++ b/flanker/utils.py
@@ -7,8 +7,8 @@ import re
 import cchardet
 import chardet
 
-from flanker.mime.message import errors
 from functools import wraps
+from flanker.mime.message import errors
 
 
 def _guess_and_convert(value):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.41',
+      version='0.4.55',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/mime/message/create_test.py
+++ b/tests/mime/message/create_test.py
@@ -60,10 +60,10 @@ def create_singlepart_ascii_test():
     eq_("Hello", message.body)
 
 
-def create_singlepart_unicode_test():
+def create_singlepart_unicode_qp_test():
     message = create.text("plain", u"Привет, курилка")
     message = create.from_string(message.to_string())
-    eq_("base64", message.content_encoding.value)
+    eq_("quoted-printable", message.content_encoding.value)
     eq_(u"Привет, курилка", message.body)
 
 
@@ -127,7 +127,8 @@ def create_multipart_with_attachment_test():
 
 
 def create_multipart_with_text_non_unicode_attachment_test():
-    """Make sure we encode text attachment in base64
+    """
+    Make sure we encode text attachment in base64
     """
     message = create.multipart("mixed")
     filename = "text-attachment.txt"

--- a/tests/mime/message/part_test.py
+++ b/tests/mime/message/part_test.py
@@ -247,14 +247,14 @@ def parse_then_serialize_malformed_message_test():
     eq_(OUTLOOK_EXPRESS, serialized)
 
 
-def ascii_to_unicode_test():
-    """Make sure that ascii uprades to unicode whenever needed"""
+def ascii_to_quoted_printable_test():
+    """Make sure that ascii uprades to quoted-printable whenever needed"""
     # contains unicode chars
     message = scan(TEXT_ONLY)
     unicode_value = u'☯Привет! Как дела? Что делаешь?,\n Что новенького?☯'
     message.body = unicode_value
     message = scan(message.to_string())
-    eq_('base64', message.content_encoding.value)
+    eq_('quoted-printable', message.content_encoding.value)
     eq_('utf-8', message.content_type.get_charset())
     eq_(unicode_value, message.body)
 


### PR DESCRIPTION
Purpose:
Text portions of MIME containing non-ascii characters are base64 encoded. The text portions still largely ascii and base64 encoding the entire body increases the size of the payload substantially. Quoted-printable is better suited for this.

As part of this work, also - added optional metric subsystem in Flanker which can be enabled via environment variables.