### PR TITLE
Change default charset when decoding mime parts

### DIFF
--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -100,7 +100,7 @@ class ContentType(tuple):
             self.get_boundary(), "--" if final else "")
 
     def get_charset(self):
-        default = 'ascii' if self.main == 'text' else None
+        default = 'utf-8' if self.main == 'text' else None
         c = self.params.get("charset", default)
         if c:
             c = c.lower()


### PR DESCRIPTION
We can safely decode text mime parts with utf-8 instead of ascii because ascii is just a subset of utf-8