### PR TITLE
Add support for Unicode strings in email addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ nosetests.xml
 
 # Editor temp files
 *.swp
+
+# PLY
+parser.out
+parsetab.py

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -36,16 +36,24 @@ See the parser.py module for implementation details of the parser.
 
 import time
 import flanker.addresslib.parser
+import flanker.addresslib.lexer
+import ply.lex
+import ply.yacc
 from flanker.addresslib.quote import smart_unquote, smart_quote
 import flanker.addresslib.validate
+import logging
 
-from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
 from flanker.utils import is_pure_ascii
 from flanker.utils import metrics_wrapper
 from flanker.mime.message.headers.encoding import encode_string
 from flanker.mime.message.headers.encodedword import mime_to_unicode
 from urlparse import urlparse
 
+log = logging.getLogger(__name__)
+
+MAX_ADDRESS_LENGTH = 1024
+MAX_ADDRESS_NUMBER = 1024
+MAX_ADDRESS_LIST_LENGTH = MAX_ADDRESS_LENGTH * MAX_ADDRESS_NUMBER
 
 @metrics_wrapper()
 def parse(address, addr_spec_only=False, metrics=False):
@@ -73,27 +81,93 @@ def parse(address, addr_spec_only=False, metrics=False):
         None
     """
     mtimes = {'parsing': 0}
+    lexer = flanker.addresslib.lexer.lexer.clone()
+    if addr_spec_only:
+        parser = flanker.addresslib.parser.addr_spec_parser
+    else:
+        parser = flanker.addresslib.parser.mailbox_or_url_parser
 
-    parser = flanker.addresslib.parser._AddressParser(False)
+    # normalize inputs to bytestrings
+    if isinstance(address, unicode):
+        address = address.encode('utf-8')
 
-    try:
-        # addr-spec only
-        if addr_spec_only:
-            bstart = time.time()
-            retval = parser.address_spec(address)
-            mtimes['parsing'] = time.time() - bstart
-            return retval, mtimes
-
-        # full address
-        bstart = time.time()
-        retval = parser.address(address)
-        mtimes['parsing'] = time.time() - bstart
-        return retval, mtimes
-
-    # supress any exceptions and return None
-    except flanker.addresslib.parser.ParserException:
+    # sanity checks
+    if not address:
         return None, mtimes
 
+    try:
+        bstart = time.time()
+        retval = _lift_parser_result(parser.parse(address, lexer=lexer))
+        mtimes['parsing'] = time.time() - bstart
+    except ply.lex.LexError as e:
+        log.warning(u'error in lexing: %s', e)
+        return None, mtimes
+    except ply.yacc.YaccError as e:
+        log.warning(u'error in parsing: %s', e)
+        return None, mtimes
+    except SyntaxError as e:
+        log.warning(u'error in parsing: %s', e)
+        return None, mtimes
+
+    if retval and len(retval.address) > MAX_ADDRESS_LENGTH:
+        log.warning('address length exceeds maximum address length of %s', MAX_ADDRESS_LENGTH)
+        return None, mtimes
+
+    return retval, mtimes
+
+
+@metrics_wrapper()
+def parse_discrete_list(address_list, metrics=False):
+    """
+    Given an string, returns an AddressList object (an iterable list
+    representing parsed email addresses and urls).
+
+    Returns an AddressList object and optionally metrics on processing
+    time if requested.
+
+    Examples:
+        >>> address.parse_list('A <a@b>')
+        [A <a@b>]
+
+        >>> address.parse_list('A <a@b>, C <d@e>')
+        [A <a@b>, C <d@e>]
+
+        >>> address.parse_list('A <a@b>, C, D <d@e>')
+        None
+
+        >>> address.parse_list('A <a@b>, D <d@e>, http://localhost')
+        [A <a@b>, D <d@e>, http://localhost]
+    """
+    mtimes = {'parsing': 0}
+    lexer = flanker.addresslib.lexer.lexer.clone()
+    parser = flanker.addresslib.parser.mailbox_or_url_list_parser
+
+    # normalize inputs to bytestrings
+    if isinstance(address_list, unicode):
+        address_list = address_list.encode('utf-8')
+
+    # sanity checks
+    if not address_list:
+        return None, mtimes
+    elif len(address_list) > MAX_ADDRESS_LIST_LENGTH:
+        log.warning('address list length exceeds maximum address list length of %s', MAX_ADDRESS_LIST_LENGTH)
+        return None, mtimes
+
+    try:
+        bstart = time.time()
+        retval = _lift_parser_result(parser.parse(address_list, lexer=lexer))
+        mtimes['parsing'] = time.time() - bstart
+    except ply.lex.LexError as e:
+        log.warning(u'error in lexing: %s', e)
+        return None, mtimes
+    except ply.yacc.YaccError as e:
+        log.warning(u'error in parsing: %s', e)
+        return None, mtimes
+    except SyntaxError as e:
+        log.warning(u'error in parsing: %s', e)
+        return None, mtimes
+
+    return retval, mtimes
 
 @metrics_wrapper()
 def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
@@ -101,10 +175,6 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
     Given an string or list of email addresses and/or urls seperated by a
     delimiter (comma (,) or semi-colon (;)), returns an AddressList object
     (an iterable list representing parsed email addresses and urls).
-
-    The Parser operates in strict or relaxed modes. In strict mode the parser
-    will quit at the first occurrence of error, in relaxed mode the parser
-    will attempt to seek to to known valid location and continue parsing.
 
     The parser can return a list of parsed addresses or a tuple containing
     the parsed and unparsed portions. The parser also returns the parsing
@@ -118,37 +188,58 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
         [A <a@b>, C <d@e>]
 
         >>> address.parse_list('A <a@b>, C, D <d@e>')
-        [A <a@b>, D <d@e>]
+        []
 
-        >>> address.parse_list('A <a@b>, C, D <d@e>')
-        [A <a@b>]
+        >>> address.parse_list(['A <a@b>', 'C', 'D <d@e>'], as_tuple=True)
+        ([A <a@b>, D <d@e>], ['C'])
 
         >>> address.parse_list('A <a@b>, D <d@e>, http://localhost')
         [A <a@b>, D <d@e>, http://localhost]
     """
+    if strict:
+        log.warning('strict parsing has been removed, ignoring')
+
     mtimes = {'parsing': 0}
-    parser = flanker.addresslib.parser._AddressParser(strict)
 
-    # if we have a list, transform it into a string first
-    if isinstance(address_list, list):
-        address_list = ', '.join(_normalize_address_list(address_list))
-
-    # parse
-    try:
-        bstart = time.time()
-        if strict:
-            p = parser.address_list(address_list)
-            u = []
+    if not address_list:
+        parsed, unparsed = AddressList(), []
+    elif isinstance(address_list, list) and len(address_list) > MAX_ADDRESS_NUMBER:
+        log.warning('address list exceeds maximum address list items of %s', MAX_ADDRESS_NUMBER)
+        parsed, unparsed = AddressList(), [address_list]
+    elif isinstance(address_list, list):
+        parsed, unparsed = AddressList(), []
+        for address in address_list:
+            if isinstance(address, basestring):
+                retval, metrics = parse(address, metrics=True)
+                mtimes['parsing'] += metrics['parsing']
+                if retval:
+                    parsed.append(retval)
+                else:
+                    unparsed.append(address)
+            elif isinstance(address, EmailAddress):
+                parsed.append(address)
+            elif isinstance(address, UrlAddress):
+                parsed.append(address)
+            else:
+                log.warning('couldnt attempt to parse address list item')
+                unparsed.append(address)
+    elif isinstance(address_list, basestring) and len(address_list) > MAX_ADDRESS_LIST_LENGTH:
+        log.warning('address list exceeds maximum address list length of %s', MAX_ADDRESS_LIST_LENGTH)
+        parsed, unparsed = AddressList(), [address_list]
+    elif isinstance(address_list, basestring):
+        retval, metrics = parse_discrete_list(address_list, metrics=True)
+        mtimes['parsing'] += metrics['parsing']
+        if retval:
+            parsed, unparsed = retval, []
         else:
-            p, u = parser.address_list(address_list)
-        mtimes['parsing'] = time.time() - bstart
-    except flanker.addresslib.parser.ParserException:
-        p, u = (AddressList(), [])
+            parsed, unparsed = AddressList(), [address_list]
+    else:
+        log.warning('couldnt attempt to parse address list')
+        parsed, unparsed = AddressList(), [address_list]
 
-    # return as tuple or just parsed addresses
     if as_tuple:
-        return p, u, mtimes
-    return p, mtimes
+        return parsed, unparsed, mtimes
+    return parsed, mtimes
 
 
 @metrics_wrapper()
@@ -176,8 +267,6 @@ def validate_address(addr_spec, metrics=False):
 
     # sanity check
     if addr_spec is None:
-        return None, mtimes
-    if not is_pure_ascii(addr_spec):
         return None, mtimes
 
     # preparse address into its parts and perform any ESP specific pre-parsing
@@ -234,15 +323,15 @@ def validate_list(addr_list, as_tuple=False, metrics=False):
     mtimes = {'parsing': 0, 'mx_lookup': 0,
         'dns_lookup': 0, 'mx_conn':0 , 'custom_grammar':0}
 
-    if addr_list is None:
-        return None, mtimes
+    if not addr_list:
+        return AddressList(), mtimes
 
     # parse addresses
     bstart = time.time()
     parsed_addresses, unparseable = parse_list(addr_list, as_tuple=True)
     mtimes['parsing'] = time.time() - bstart
 
-    plist = flanker.addresslib.address.AddressList()
+    plist = AddressList()
     ulist = []
 
     # make sure parsed list pass dns and esp grammar
@@ -250,7 +339,7 @@ def validate_list(addr_list, as_tuple=False, metrics=False):
 
         # lookup if this domain has a mail exchanger
         exchanger, mx_metrics = \
-            flanker.addresslib.validate.mail_exchanger_lookup(paddr.hostname, metrics=True)
+            flanker.addresslib.validate.mail_exchanger_lookup(paddr.domain, metrics=True)
         mtimes['mx_lookup'] += mx_metrics['mx_lookup']
         mtimes['dns_lookup'] += mx_metrics['dns_lookup']
         mtimes['mx_conn'] += mx_metrics['mx_conn']
@@ -262,7 +351,7 @@ def validate_list(addr_list, as_tuple=False, metrics=False):
         # lookup custom local-part grammar if it exists
         plugin = flanker.addresslib.validate.plugin_for_esp(exchanger)
         bstart = time.time()
-        if plugin and plugin.validate(paddr.mailbox) is False:
+        if plugin and plugin.validate(paddr.local_part) is False:
             ulist.append(paddr.full_spec())
             continue
         mtimes['custom_grammar'] = time.time() - bstart
@@ -345,27 +434,73 @@ class EmailAddress(Address):
        'Bob Silva <bob@host.com>'
     """
 
-    __slots__ = ['display_name', 'mailbox', 'hostname', 'address']
+    display_name = None
+    local_part = None
+    domain = None
+    addr_type = Address.Type.Email
 
-    def __init__(self, display_name, spec=None, parsed_name=None):
-        if spec is None:
-            spec = display_name
-            display_name = None
+    def __init__(self, raw_display_name=None, raw_addr_spec=None, display_name=None, local_part=None, domain=None):
 
-        assert(spec)
+        if raw_display_name and raw_addr_spec:
+            if isinstance(raw_addr_spec, unicode):
+                raw_addr_spec = raw_addr_spec.encode('utf-8')
 
-        if parsed_name:
-            self.display_name = smart_unquote(mime_to_unicode(parsed_name))
-        elif display_name:
-            self.display_name = display_name
+            lexer = flanker.addresslib.lexer.lexer.clone()
+            parser = flanker.addresslib.parser.addr_spec_parser
+            mailbox = parser.parse(raw_addr_spec, lexer=lexer)
+
+            self.display_name = raw_display_name
+            self.local_part = mailbox.local_part.decode('utf-8')
+            self.domain = mailbox.domain.decode('utf-8')
+
+            if self.display_name.startswith('"') and self.display_name.endswith('"') and self.display_name != '""':
+                self.display_name = smart_unquote(self.display_name)
+
+        elif raw_display_name:
+            if isinstance(raw_display_name, unicode):
+                raw_display_name = raw_display_name.encode('utf-8')
+
+            lexer = flanker.addresslib.lexer.lexer.clone()
+            parser = flanker.addresslib.parser.mailbox_parser
+            mailbox = parser.parse(raw_display_name, lexer=lexer)
+
+            self.display_name = smart_unquote(mailbox.display_name.decode('utf-8'))
+            self.local_part = mailbox.local_part.decode('utf-8')
+            self.domain = mailbox.domain.decode('utf-8')
+
+        elif raw_addr_spec:
+            if isinstance(raw_addr_spec, unicode):
+                raw_addr_spec = raw_addr_spec.encode('utf-8')
+
+            lexer = flanker.addresslib.lexer.lexer.clone()
+            parser = flanker.addresslib.parser.addr_spec_parser
+            mailbox = parser.parse(raw_addr_spec, lexer=lexer)
+
+            self.display_name = ''
+            self.local_part = mailbox.local_part.decode('utf-8')
+            self.domain = mailbox.domain.decode('utf-8')
+
+        elif local_part and domain:
+            self.display_name = display_name or ''
+            self.local_part = local_part
+            self.domain = domain
+
         else:
-            self.display_name = u''
+            raise SyntaxError('failed to create EmailAddress: bad parameters')
 
-        parts = spec.rsplit('@', 1)
-        self.mailbox = parts[0]
-        self.hostname = parts[1].lower()
-        self.address = self.mailbox + "@" + self.hostname
-        self.addr_type = self.Type.Email
+    @property
+    def address(self):
+        return u'{}@{}'.format(self.local_part, self.domain.lower())
+
+    @property
+    def mailbox(self):
+        log.warning('deprecation notice: `mailbox` as been renamed `local_part` to match the nomenclature in RFC 5322 and will be removed in a future version')
+        return self.local_part
+
+    @property
+    def hostname(self):
+        log.warning('deprecation notice: `hostname` as been renamed `domain` to match the nomenclature in RFC 5322 and will be removed in a future version')
+        return self.domain.lower()
 
     def __repr__(self):
         """
@@ -419,11 +554,9 @@ class EmailAddress(Address):
         """
         Allows comparison of two addresses.
         """
+        if isinstance(other, basestring):
+            other = parse(other)
         if other:
-            if isinstance(other, basestring):
-                other = parse(other)
-                if not other:
-                    return False
             return self.address.lower() == other.address.lower()
         return False
 
@@ -469,30 +602,40 @@ class UrlAddress(Address):
     data", use the parse() and parse_list() functions instead.
     """
 
-    __slots__ = ['address', 'parse_result']
+    address = None
+    addr_type = Address.Type.Url
 
-    def __init__(self, spec):
-        self.address = spec
-        self.parse_result = urlparse(spec)
-        self.addr_type = self.Type.Url
+    def __init__(self, raw=None, address=None):
+
+        if raw:
+            if isinstance(raw, unicode):
+                raw = raw.encode('utf-8')
+            lexer = flanker.addresslib.lexer.lexer.clone()
+            parser = flanker.addresslib.parser.url_parser
+            url = parser.parse(raw, lexer=lexer)
+            self.address = url.address.decode('utf-8')
+        elif address:
+            self.address = address
+        else:
+            raise SyntaxError('failed to create UrlAddress: bad parameters')
 
     @property
     def hostname(self):
-        hostname = self.parse_result.hostname
+        hostname = urlparse(self.address).hostname
         if hostname:
             return hostname.lower()
 
     @property
     def port(self):
-        return self.parse_result.port
+        return urlparse(self.address).port
 
     @property
     def scheme(self):
-        return self.parse_result.scheme
+        return urlparse(self.address).scheme
 
     @property
     def path(self):
-        return self.parse_result.path
+        return urlparse(self.address).path
 
     def __str__(self):
         return self.address
@@ -508,10 +651,11 @@ class UrlAddress(Address):
 
     def __eq__(self, other):
         "Allows comparison of two URLs"
+        if isinstance(other, basestring):
+            other = parse(other)
         if other:
-            if not isinstance(other, basestring):
-                other = other.address
-            return self.address == other
+            return self.address == other.address
+        return False
 
     def __hash__(self):
         return hash(self.address)
@@ -532,10 +676,13 @@ class AddressList(object):
         True
     """
 
+    container = None
+
     def __init__(self, container=None):
         if container is None:
-            container = []
-        self.container = container
+            self.container = []
+        else:
+            self.container = container
 
     def append(self, n):
         self.container.append(n)
@@ -557,6 +704,8 @@ class AddressList(object):
         When comparing ourselves to other lists we must ignore order.
         """
         if isinstance(other, list):
+            other = parse_list(other)
+        if isinstance(other, basestring):
             other = parse_list(other)
         return set(self.container) == set(other.container)
 
@@ -617,13 +766,16 @@ class AddressList(object):
         return set([addr.addr_type for addr in self.container])
 
 
-def _normalize_address_list(address_list):
-    parts = []
-
-    for addr in address_list:
-        if isinstance(addr, Address):
-            parts.append(addr.to_unicode())
-        if isinstance(addr, basestring):
-            parts.append(addr)
-
-    return parts
+def _lift_parser_result(retval):
+    if isinstance(retval, flanker.addresslib.parser.Mailbox):
+        return EmailAddress(
+            display_name=smart_unquote(retval.display_name.decode('utf-8')),
+            local_part=retval.local_part.decode('utf-8'),
+            domain=retval.domain.decode('utf-8'))
+    if isinstance(retval, flanker.addresslib.parser.Url):
+        return UrlAddress(
+            address=retval.address.decode('utf-8'))
+    if isinstance(retval, list):
+        return AddressList(
+            map(_lift_parser_result, retval))
+    return None

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -573,21 +573,21 @@ class EmailAddress(Address):
         return u'{}@{}'.format(self.local_part, self.domain)
 
     def contains_non_ascii(self):
-        '''
+        """
         Does the address contain any non-ASCII characters?
-        '''
+        """
         return not is_pure_ascii(self.address)
 
     def requires_non_ascii(self):
-        '''
+        """
         Can the address be converted to an ASCII compatible encoding?
-        '''
+        """
         return not is_pure_ascii(self.local_part)
 
     def contains_domain_literal(self):
-        '''
+        """
         Is the address a domain literal?
-        '''
+        """
         return self.domain.startswith('[') and self.domain.endswith(']')
 
     def __cmp__(self, other):

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -534,26 +534,15 @@ class EmailAddress(Address):
 
     def full_spec(self):
         """
-        Returns a normalized email address as a bytestring. ASCII-compatable
-        encoding will be returned if possible. If an ASCII-compatable encoding
-        is not possible then any non-ASCII characters will be unchanged.
+        Returns an ASCII-compatable encoding of an email address or raises a
+        ValueException. Display name and domain parts will be converted to
+        ASCII-compatable encoding. The transformed address will be ASCII-only
+        and RFC-2822 compliant.
 
            >>> EmailAddress("Ev K", "ev@example.com").full_spec()
            'Ev K <ev@example.com>'
            >>> EmailAddress("Жека", "ev@example.com").full_spec()
            '=?utf-8?b?0JbQtdC60LA=?= <ev@example.com>'
-        """
-        if self.requires_non_ascii():
-            return self.to_unicode().encode('utf-8')
-        else:
-            return self.to_ace().encode('utf-8')
-
-    def to_ace(self):
-        """
-        Returns an ASCII-compatable encoding of an email address or raises a
-        ValueException. Display name and domain parts will be converted to
-        ASCII-compatable encoding. The transformed address will be ASCII-only
-        and RFC-2822 compliant.
         """
         if not is_pure_ascii(self.local_part):
             raise ValueError('address {} has no ASCII-compatable encoding'.format(self.address.encode('utf-8')))
@@ -561,8 +550,8 @@ class EmailAddress(Address):
         if self.display_name:
             ace_display_name = smart_quote(encode_string(
                 None, self.display_name, maxlinelen=MAX_ADDRESS_LENGTH))
-            return u'{} <{}@{}>'.format(ace_display_name, self.local_part, ace_domain)
-        return u'{}@{}'.format(self.local_part, ace_domain)
+            return '{} <{}@{}>'.format(ace_display_name, self.local_part, ace_domain)
+        return '{}@{}'.format(self.local_part, ace_domain)
 
     def to_unicode(self):
         """

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -644,15 +644,15 @@ class UrlAddress(Address):
                 raw = raw.encode('utf-8')
             parser = url_parser
             url = parser.parse(raw, lexer=lexer.clone())
-            self._address = url.address.decode('utf-8')
+            self._address = urlparse(url.address)
         elif address:
-            self._address = address
+            self._address = urlparse(address)
         else:
             raise SyntaxError('failed to create UrlAddress: bad parameters')
 
     @property
     def address(self):
-        return self._address
+        return self._address.geturl()
 
     @property
     def addr_type(self):
@@ -660,21 +660,23 @@ class UrlAddress(Address):
 
     @property
     def hostname(self):
-        hostname = urlparse(self._address).hostname
+        hostname = self._address.hostname
         if hostname:
             return hostname.lower()
+        else:
+            return None
 
     @property
     def port(self):
-        return urlparse(self._address).port
+        return self._address.port
 
     @property
     def scheme(self):
-        return urlparse(self._address).scheme
+        return self._address.scheme
 
     @property
     def path(self):
-        return urlparse(self._address).path
+        return self._address.path
 
     def __str__(self):
         return self.address

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -408,12 +408,12 @@ class EmailAddress(Address):
     or parse_list() functions to return a scalar or iterable list respectively.
 
     Examples:
-       >>> addr = EmailAddress("Bob Silva", "bob@host.com")
+       >>> addr = parse("Bob Silva", "bob@host.com")
        >>> addr.address
        'bob@host.com'
-       >>> addr.hostname
+       >>> addr.domain
        'host.com'
-       >>> addr.mailbox
+       >>> addr.local_part
        'bob'
 
     Display name is always returned in Unicode, i.e. ready to be displayed on
@@ -422,7 +422,7 @@ class EmailAddress(Address):
        >>> addr.display_name
        u'Bob Silva'
 
-    And full email spec is 100% ASCII, encoded for MIME:
+    And full email spec is always returned as a sting encoded for MIME:
        >>> addr.full_spec()
        'Bob Silva <bob@host.com>'
     """
@@ -631,7 +631,7 @@ class EmailAddress(Address):
 class UrlAddress(Address):
     """
     Represents a parsed URL:
-        >>> url = UrlAddress("http://user@host.com:8080?q=a")
+        >>> url = parse("http://user@host.com:8080?q=a")
         >>> url.hostname
         'host.com'
         >>> url.port

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -200,7 +200,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
         parsed, unparsed = AddressList(), []
     elif isinstance(address_list, list) and len(address_list) > MAX_ADDRESS_NUMBER:
         log.warning('address list exceeds maximum items of %s', MAX_ADDRESS_NUMBER)
-        parsed, unparsed = AddressList(), [address_list]
+        parsed, unparsed = AddressList(), address_list
     elif isinstance(address_list, list):
         parsed, unparsed = AddressList(), []
         for address in address_list:
@@ -230,7 +230,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
             parsed, unparsed = AddressList(), [address_list]
     else:
         log.warning('couldnt attempt to parse address list')
-        parsed, unparsed = AddressList(), [address_list]
+        parsed, unparsed = AddressList(), None
 
     if as_tuple:
         return parsed, unparsed, mtimes

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -548,27 +548,30 @@ class EmailAddress(Address):
 
     def full_spec(self):
         """
-        Returns a full spec of an email address. Always in ASCII, RFC-2822
-        compliant, safe to be included into MIME:
+        Returns a full spec of an email address. Display name and domain parts
+        will be converted to ASCII-compatable encoding. The transformed address
+        will be ASCII-only and RFC-2822 compliant if the local part is
+        ASCII-only.
 
            >>> EmailAddress("Ev K", "ev@example.com").full_spec()
            'Ev K <ev@host.com>'
            >>> EmailAddress("Жека", "ev@example.com").full_spec()
            '=?utf-8?b?0JbQtdC60LA=?= <ev@example.com>'
         """
+        ace_domain = self.domain.lower().encode('idna')
         if self.display_name:
-            encoded_display_name = smart_quote(encode_string(
+            ace_display_name = smart_quote(encode_string(
                 None, self.display_name, maxlinelen=MAX_ADDRESS_LENGTH))
-            return '{0} <{1}>'.format(encoded_display_name, self.address)
-        return u'{0}'.format(self.address)
+            return u'{} <{}@{}>'.format(ace_display_name, self.local_part, ace_domain).encode('utf-8')
+        return u'{}@{}'.format(self.local_part, ace_domain).encode('utf-8')
 
     def to_unicode(self):
         """
         Converts to unicode.
         """
         if self.display_name:
-            return u'{0} <{1}>'.format(self.display_name, self.address)
-        return u'{0}'.format(self.address)
+            return u'{} <{}@{}>'.format(self.display_name, self.local_part, self.domain)
+        return u'{}@{}'.format(self.local_part, self.domain)
 
     def __cmp__(self, other):
         return True

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -535,7 +535,7 @@ class EmailAddress(Address):
     def full_spec(self):
         """
         Returns an ASCII-compatable encoding of an email address or raises a
-        ValueException. Display name and domain parts will be converted to
+        ValueError. Display name and domain parts will be converted to
         ASCII-compatable encoding. The transformed address will be ASCII-only
         and RFC-2822 compliant.
 

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -573,6 +573,24 @@ class EmailAddress(Address):
             return u'{} <{}@{}>'.format(self.display_name, self.local_part, self.domain)
         return u'{}@{}'.format(self.local_part, self.domain)
 
+    def contains_non_ascii(self):
+        '''
+        Does the address contain any non-ASCII characters?
+        '''
+        return not is_pure_ascii(self.address)
+
+    def requires_non_ascii(self):
+        '''
+        Can the address be converted to an ASCII compatible encoding?
+        '''
+        return not is_pure_ascii(self.local_part)
+
+    def contains_domain_literal(self):
+        '''
+        Is the address a domain literal?
+        '''
+        return self.domain.startswith('[') and self.domain.endswith(']')
+
     def __cmp__(self, other):
         return True
 

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -434,10 +434,10 @@ class EmailAddress(Address):
        'Bob Silva <bob@host.com>'
     """
 
-    display_name = None
-    local_part = None
-    domain = None
-    addr_type = Address.Type.Email
+    _display_name = None
+    _local_part = None
+    _domain = None
+    _addr_type = Address.Type.Email
 
     def __init__(self, raw_display_name=None, raw_addr_spec=None, display_name=None, local_part=None, domain=None):
 
@@ -449,12 +449,12 @@ class EmailAddress(Address):
             parser = flanker.addresslib.parser.addr_spec_parser
             mailbox = parser.parse(raw_addr_spec, lexer=lexer)
 
-            self.display_name = raw_display_name
-            self.local_part = mailbox.local_part.decode('utf-8')
-            self.domain = mailbox.domain.decode('utf-8')
+            self._display_name = raw_display_name
+            self._local_part = mailbox.local_part.decode('utf-8')
+            self._domain = mailbox.domain.decode('utf-8')
 
-            if self.display_name.startswith('"') and self.display_name.endswith('"') and self.display_name != '""':
-                self.display_name = smart_unquote(self.display_name)
+            if self._display_name.startswith('"') and self._display_name.endswith('"') and self._display_name != '""':
+                self._display_name = smart_unquote(self._display_name)
 
         elif raw_display_name:
             if isinstance(raw_display_name, unicode):
@@ -464,9 +464,12 @@ class EmailAddress(Address):
             parser = flanker.addresslib.parser.mailbox_parser
             mailbox = parser.parse(raw_display_name, lexer=lexer)
 
-            self.display_name = smart_unquote(mailbox.display_name.decode('utf-8'))
-            self.local_part = mailbox.local_part.decode('utf-8')
-            self.domain = mailbox.domain.decode('utf-8')
+            self._display_name = mailbox.display_name.decode('utf-8')
+            self._local_part = mailbox.local_part.decode('utf-8')
+            self._domain = mailbox.domain.decode('utf-8')
+
+            if self._display_name.startswith('"') and self._display_name.endswith('"') and self._display_name != '""':
+                self._display_name = smart_unquote(self._display_name)
 
         elif raw_addr_spec:
             if isinstance(raw_addr_spec, unicode):
@@ -476,17 +479,37 @@ class EmailAddress(Address):
             parser = flanker.addresslib.parser.addr_spec_parser
             mailbox = parser.parse(raw_addr_spec, lexer=lexer)
 
-            self.display_name = ''
-            self.local_part = mailbox.local_part.decode('utf-8')
-            self.domain = mailbox.domain.decode('utf-8')
+            self._display_name = ''
+            self._local_part = mailbox.local_part.decode('utf-8')
+            self._domain = mailbox.domain.decode('utf-8')
 
         elif local_part and domain:
-            self.display_name = display_name or ''
-            self.local_part = local_part
-            self.domain = domain
+            self._display_name = display_name or ''
+            self._local_part = local_part
+            self._domain = domain
 
         else:
             raise SyntaxError('failed to create EmailAddress: bad parameters')
+
+    @property
+    def display_name(self):
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        self._display_name = display_name
+
+    @property
+    def local_part(self):
+        return self._local_part
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @property
+    def addr_type(self):
+        return self._addr_type
 
     @property
     def address(self):
@@ -495,12 +518,12 @@ class EmailAddress(Address):
     @property
     def mailbox(self):
         log.warning('deprecation notice: `mailbox` as been renamed `local_part` to match the nomenclature in RFC 5322 and will be removed in a future version')
-        return self.local_part
+        return self._local_part
 
     @property
     def hostname(self):
         log.warning('deprecation notice: `hostname` as been renamed `domain` to match the nomenclature in RFC 5322 and will be removed in a future version')
-        return self.domain.lower()
+        return self._domain.lower()
 
     def __repr__(self):
         """
@@ -602,8 +625,8 @@ class UrlAddress(Address):
     data", use the parse() and parse_list() functions instead.
     """
 
-    address = None
-    addr_type = Address.Type.Url
+    _address = None
+    _addr_type = Address.Type.Url
 
     def __init__(self, raw=None, address=None):
 
@@ -613,29 +636,37 @@ class UrlAddress(Address):
             lexer = flanker.addresslib.lexer.lexer.clone()
             parser = flanker.addresslib.parser.url_parser
             url = parser.parse(raw, lexer=lexer)
-            self.address = url.address.decode('utf-8')
+            self._address = url.address.decode('utf-8')
         elif address:
-            self.address = address
+            self._address = address
         else:
             raise SyntaxError('failed to create UrlAddress: bad parameters')
 
     @property
+    def address(self):
+        return self._address
+
+    @property
+    def addr_type(self):
+        return self._addr_type
+
+    @property
     def hostname(self):
-        hostname = urlparse(self.address).hostname
+        hostname = urlparse(self._address).hostname
         if hostname:
             return hostname.lower()
 
     @property
     def port(self):
-        return urlparse(self.address).port
+        return urlparse(self._address).port
 
     @property
     def scheme(self):
-        return urlparse(self.address).scheme
+        return urlparse(self._address).scheme
 
     @property
     def path(self):
-        return urlparse(self.address).path
+        return urlparse(self._address).path
 
     def __str__(self):
         return self.address

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -94,6 +94,9 @@ def parse(address, addr_spec_only=False, metrics=False):
     # sanity checks
     if not address:
         return None, mtimes
+    if len(address) > MAX_ADDRESS_LENGTH:
+        log.warning('address exceeds maximum length of %s', MAX_ADDRESS_LENGTH)
+        return None, mtimes
 
     try:
         bstart = time.time()
@@ -107,10 +110,6 @@ def parse(address, addr_spec_only=False, metrics=False):
         return None, mtimes
     except SyntaxError as e:
         log.warning(u'error in parsing: %s', e)
-        return None, mtimes
-
-    if retval and len(retval.address) > MAX_ADDRESS_LENGTH:
-        log.warning('address length exceeds maximum address length of %s', MAX_ADDRESS_LENGTH)
         return None, mtimes
 
     return retval, mtimes
@@ -150,7 +149,7 @@ def parse_discrete_list(address_list, metrics=False):
     if not address_list:
         return None, mtimes
     elif len(address_list) > MAX_ADDRESS_LIST_LENGTH:
-        log.warning('address list length exceeds maximum address list length of %s', MAX_ADDRESS_LIST_LENGTH)
+        log.warning('address list exceeds maximum length of %s', MAX_ADDRESS_LIST_LENGTH)
         return None, mtimes
 
     try:
@@ -204,7 +203,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
     if not address_list:
         parsed, unparsed = AddressList(), []
     elif isinstance(address_list, list) and len(address_list) > MAX_ADDRESS_NUMBER:
-        log.warning('address list exceeds maximum address list items of %s', MAX_ADDRESS_NUMBER)
+        log.warning('address list exceeds maximum items of %s', MAX_ADDRESS_NUMBER)
         parsed, unparsed = AddressList(), [address_list]
     elif isinstance(address_list, list):
         parsed, unparsed = AddressList(), []
@@ -224,7 +223,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
                 log.warning('couldnt attempt to parse address list item')
                 unparsed.append(address)
     elif isinstance(address_list, basestring) and len(address_list) > MAX_ADDRESS_LIST_LENGTH:
-        log.warning('address list exceeds maximum address list length of %s', MAX_ADDRESS_LIST_LENGTH)
+        log.warning('address list exceeds maximum length of %s', MAX_ADDRESS_LIST_LENGTH)
         parsed, unparsed = AddressList(), [address_list]
     elif isinstance(address_list, basestring):
         retval, metrics = parse_discrete_list(address_list, metrics=True)

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -548,22 +548,35 @@ class EmailAddress(Address):
 
     def full_spec(self):
         """
-        Returns a full spec of an email address. Display name and domain parts
-        will be converted to ASCII-compatable encoding. The transformed address
-        will be ASCII-only and RFC-2822 compliant if the local part is
-        ASCII-only.
+        Returns a normalized email address as a bytestring. ASCII-compatable
+        encoding will be returned if possible. If an ASCII-compatable encoding
+        is not possible then any non-ASCII characters will be unchanged.
 
            >>> EmailAddress("Ev K", "ev@example.com").full_spec()
-           'Ev K <ev@host.com>'
+           'Ev K <ev@example.com>'
            >>> EmailAddress("Жека", "ev@example.com").full_spec()
            '=?utf-8?b?0JbQtdC60LA=?= <ev@example.com>'
         """
+        if self.requires_non_ascii():
+            return self.to_unicode().encode('utf-8')
+        else:
+            return self.to_ace().encode('utf-8')
+
+    def to_ace(self):
+        """
+        Returns an ASCII-compatable encoding of an email address or raises a
+        ValueException. Display name and domain parts will be converted to
+        ASCII-compatable encoding. The transformed address will be ASCII-only
+        and RFC-2822 compliant.
+        """
+        if not is_pure_ascii(self.local_part):
+            raise ValueError('address {} has no ASCII-compatable encoding'.format(self.address.encode('utf-8')))
         ace_domain = self.domain.lower().encode('idna')
         if self.display_name:
             ace_display_name = smart_quote(encode_string(
                 None, self.display_name, maxlinelen=MAX_ADDRESS_LENGTH))
-            return u'{} <{}@{}>'.format(ace_display_name, self.local_part, ace_domain).encode('utf-8')
-        return u'{}@{}'.format(self.local_part, ace_domain).encode('utf-8')
+            return u'{} <{}@{}>'.format(ace_display_name, self.local_part, ace_domain)
+        return u'{}@{}'.format(self.local_part, ace_domain)
 
     def to_unicode(self):
         """

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -485,10 +485,6 @@ class EmailAddress(Address):
     def display_name(self):
         return self._display_name
 
-    @display_name.setter
-    def display_name(self, display_name):
-        self._display_name = display_name
-
     @property
     def local_part(self):
         return self._local_part

--- a/flanker/addresslib/lexer.py
+++ b/flanker/addresslib/lexer.py
@@ -1,0 +1,137 @@
+import ply.lex as lex
+import logging
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+states = (
+    ('domain','inclusive'),
+    ('quote', 'inclusive'),
+)
+
+tokens = (
+    'FWSP',
+    'AT',
+    'DOT',
+    'COMMA',
+    'SEMICOLON',
+    'LANGLE',
+    'RANGLE',
+    'ATEXT',
+    'LBRACKET',
+    'RBRACKET',
+    'DTEXT',
+    'DQUOTE',
+    'QTEXT',
+    'QPAIR',
+    'URL'
+)
+
+# Urls - Not a part of the message format RFC but we permit these currently
+
+def t_URL(t):
+    r'http(s)?://[^\s<>{}|^~\[\]`;,]+'
+    return t
+
+# Atoms - https://tools.ietf.org/html/rfc5322#section-3.2.3
+
+t_FWSP      = r'([\s\t]*\r\n)?[\s\t]+' # folding whitespace
+t_AT        = r'\@'                    # '@'
+t_DOT       = r'\.'                    # '.'
+t_COMMA     = r'\,'                    # ','
+t_LANGLE    = r'\<'                    # '<'
+t_RANGLE    = r'\>'                    # '>'
+t_SEMICOLON = r'\;'                    # ';'
+
+t_ATEXT = r'''
+          ( [a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~] # Visable ASCII characters not including specials
+          | [\xC2-\xDF][\x80-\xBF]                            # UTF8-2
+          | \xE0[\xA0-\xBF][\x80-\xBF]                        # UTF8-3
+          | [\xE1-\xEC][\x80-\xBF]{2}
+          | \xED[\x80-\x9F][\x80-\xBF]
+          | [\xEE-\xEF][\x80-\xBF]{2}
+          | \xF0[\x90-\xBF][\x80-\xBF]{2}                     # UTF8-4
+          | [\xF1-\xF3][\x80-\xBF]{3}
+          | \xF4[\x80-\x8F][\x80-\xBF]{2}
+          )+
+          '''
+
+def t_error(t):
+    log.warning("syntax error in default lexer, token=%s", t)
+
+# Domain literals - https://tools.ietf.org/html/rfc5322#section-3.4.1
+
+def t_LBRACKET(t):
+    r'\['
+    t.lexer.begin('domain')
+    return t
+
+def t_domain_RBRACKET(t):
+    r'\]'
+    t.lexer.begin('INITIAL')
+    return t
+
+t_domain_DTEXT = r'''
+                 ( [\x21-\x5A]                   # Visable ASCII characters not
+                 | [\x5E-\x7E]                   #   including '[', ']', or '\'
+                 | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
+                 | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
+                 | [\xE1-\xEC][\x80-\xBF]{2}
+                 | \xED[\x80-\x9F][\x80-\xBF]
+                 | [\xEE-\xEF][\x80-\xBF]{2}
+                 | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
+                 | [\xF1-\xF3][\x80-\xBF]{3}
+                 | \xF4[\x80-\x8F][\x80-\xBF]{2}
+                 )+
+                 '''
+
+def t_domain_error(t):
+    log.warning("syntax error in domain lexer, token=%s", t)
+
+# Quoted strings - https://tools.ietf.org/html/rfc5322#section-3.2.4
+
+def t_DQUOTE(t):
+    r'\"'
+    t.lexer.begin('quote')
+    return t
+
+def t_quote_DQUOTE(t):
+    r'\"'
+    t.lexer.begin('INITIAL')
+    return t
+
+t_quote_QTEXT = r'''
+                ( \x21                          # Visable ASCII characters not
+                | [\x23-\x5B]                   #   including '\' or '"'
+                | [\x5D-\x7E]
+                | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
+                | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
+                | [\xE1-\xEC][\x80-\xBF]{2}
+                | \xED[\x80-\x9F][\x80-\xBF]
+                | [\xEE-\xEF][\x80-\xBF]{2}
+                | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
+                | [\xF1-\xF3][\x80-\xBF]{3}
+                | \xF4[\x80-\x8F][\x80-\xBF]{2}
+                )+
+                '''
+t_quote_QPAIR = r'''
+                \\                              # '/'
+                ( [\x21-\x7E]                   # Visible ASCII character
+                | \s                            # ' ', technically not valid
+                | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
+                | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
+                | [\xE1-\xEC][\x80-\xBF]{2}
+                | \xED[\x80-\x9F][\x80-\xBF]
+                | [\xEE-\xEF][\x80-\xBF]{2}
+                | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
+                | [\xF1-\xF3][\x80-\xBF]{3}
+                | \xF4[\x80-\x8F][\x80-\xBF]{2}
+                )
+                '''
+
+def t_quote_error(t):
+    log.warning("syntax error in quoted string lexer, token=%s", t)
+
+
+# Build the lexer
+lexer = lex.lex(errorlog=log)

--- a/flanker/addresslib/parser.py
+++ b/flanker/addresslib/parser.py
@@ -154,7 +154,7 @@ def p_expression_fwsp(p):
 
 def p_error(p):
     if p:
-        raise SyntaxError('syntax error: token=%s, lexpos=%s', p.value, p.lexpos)
+        raise SyntaxError('syntax error: token=%s, lexpos=%s' % (p.value, p.lexpos))
     raise SyntaxError('syntax error: eof')
 
 

--- a/flanker/addresslib/validate.py
+++ b/flanker/addresslib/validate.py
@@ -124,16 +124,19 @@ def mail_exchanger_lookup(domain, metrics=False):
         return cache_value, mtimes
 
     # dns lookup on domain
-    bstart = time.time()
-    mx_hosts = lookup_domain(domain)
-    mtimes['dns_lookup'] = time.time() - bstart
-    if mx_hosts is None:
-        # try one more time
+    if domain.startswith('[') and domain.endswith(']'):
+        mx_hosts = [domain[1:-1]]
+    else:
         bstart = time.time()
         mx_hosts = lookup_domain(domain)
-        mtimes['dns_lookup'] += time.time() - bstart
+        mtimes['dns_lookup'] = time.time() - bstart
         if mx_hosts is None:
-            return None, mtimes
+            # try one more time
+            bstart = time.time()
+            mx_hosts = lookup_domain(domain)
+            mtimes['dns_lookup'] += time.time() - bstart
+            if mx_hosts is None:
+                return None, mtimes
 
     # test connecting to the mx exchanger
     bstart = time.time()

--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -1,4 +1,4 @@
-from flanker.utils import to_unicode
+from flanker.mime.message.utils import to_unicode
 
 
 def convert_to_unicode(charset, value):

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -59,7 +59,7 @@ def encode_unstructured(name, value):
 def encode_address_header(name, value):
     out = deque()
     for addr in flanker.addresslib.address.parse_list(value):
-        out.append(addr.full_spec())
+        out.append(addr.to_unicode().encode('utf-8'))
     return "; ".join(out)
 
 

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -59,7 +59,7 @@ def encode_unstructured(name, value):
 def encode_address_header(name, value):
     out = deque()
     for addr in flanker.addresslib.address.parse_list(value):
-        out.append(addr.full_spec().encode('utf-8'))
+        out.append(addr.full_spec())
     return "; ".join(out)
 
 

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -5,7 +5,7 @@ import logging
 from collections import deque
 from email.header import Header
 from flanker.mime.message.headers import parametrized
-from flanker.utils import to_utf8
+from flanker.mime.message.utils import to_utf8
 
 log = logging.getLogger(__name__)
 

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -59,7 +59,7 @@ def encode_unstructured(name, value):
 def encode_address_header(name, value):
     out = deque()
     for addr in flanker.addresslib.address.parse_list(value):
-        out.append(addr.full_spec())
+        out.append(addr.full_spec().encode('utf-8'))
     return "; ".join(out)
 
 

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -4,7 +4,8 @@ from collections import deque
 from flanker.mime.message.headers import encodedword, parametrized
 from flanker.mime.message.headers.wrappers import ContentType, WithParams
 from flanker.mime.message.errors import DecodingError
-from flanker.utils import to_unicode, is_pure_ascii
+from flanker.mime.message.utils import to_unicode
+from flanker.utils import is_pure_ascii
 
 MAX_LINE_LENGTH = 10000
 

--- a/flanker/mime/message/utils.py
+++ b/flanker/mime/message/utils.py
@@ -1,6 +1,9 @@
 from cStringIO import StringIO
 from contextlib import closing
 from email.generator import Generator
+from flanker.mime.message import errors
+import cchardet
+import chardet
 
 
 def python_message_to_string(msg):
@@ -9,3 +12,63 @@ def python_message_to_string(msg):
         g = Generator(fp, mangle_from_=False)
         g.flatten(msg, unixfrom=False)
         return fp.getvalue()
+
+def _guess_and_convert_with(value, detector=cchardet):
+    """
+    Try to guess the encoding of the passed value with the provided detector
+    and decode it.
+
+    The detector is either chardet or cchardet module.
+    """
+    charset = detector.detect(value)
+
+    if not charset["encoding"]:
+        raise errors.DecodingError("Failed to guess encoding")
+
+    try:
+        value = value.decode(charset["encoding"], "replace")
+        return value
+
+    except (UnicodeError, LookupError) as e:
+        raise errors.DecodingError(str(e))
+
+def _guess_and_convert(value):
+    """
+    Try to guess the encoding of the passed value and decode it.
+
+    Uses cchardet to guess the encoding and if guessing or decoding fails, falls
+    back to chardet which is much slower.
+    """
+    try:
+        return _guess_and_convert_with(value, detector=cchardet)
+    except:
+        return _guess_and_convert_with(value, detector=chardet)
+
+
+def _make_unicode(value, charset=None):
+    if isinstance(value, unicode):
+        return value
+
+    charset = charset or "utf-8"
+    try:
+        value = value.decode(charset, "strict")
+    except (UnicodeError, LookupError):
+        value = _guess_and_convert(value)
+
+    return value
+
+
+def to_utf8(value, charset=None):
+    '''
+    Safely returns a UTF-8 version of a given string
+    >>> utils.to_utf8(u'hi')
+        'hi'
+    '''
+
+    value = _make_unicode(value, charset)
+
+    return value.encode("utf-8", "strict")
+
+
+def to_unicode(value, charset=None):
+    return _make_unicode(value, charset)

--- a/flanker/utils.py
+++ b/flanker/utils.py
@@ -4,73 +4,7 @@ Utility functions and classes used by flanker.
 """
 import re
 
-import cchardet
-import chardet
-
 from functools import wraps
-from flanker.mime.message import errors
-
-
-def _guess_and_convert(value):
-    """
-    Try to guess the encoding of the passed value and decode it.
-
-    Uses cchardet to guess the encoding and if guessing or decoding fails, falls
-    back to chardet which is much slower.
-    """
-    try:
-        return _guess_and_convert_with(value, detector=cchardet)
-    except:
-        return _guess_and_convert_with(value, detector=chardet)
-
-
-def _guess_and_convert_with(value, detector=cchardet):
-    """
-    Try to guess the encoding of the passed value with the provided detector
-    and decode it.
-
-    The detector is either chardet or cchardet module.
-    """
-    charset = detector.detect(value)
-
-    if not charset["encoding"]:
-        raise errors.DecodingError("Failed to guess encoding")
-
-    try:
-        value = value.decode(charset["encoding"], "replace")
-        return value
-
-    except (UnicodeError, LookupError) as e:
-        raise errors.DecodingError(str(e))
-
-
-def _make_unicode(value, charset=None):
-    if isinstance(value, unicode):
-        return value
-
-    charset = charset or "utf-8"
-    try:
-        value = value.decode(charset, "strict")
-    except (UnicodeError, LookupError):
-        value = _guess_and_convert(value)
-
-    return value
-
-
-def to_unicode(value, charset=None):
-    return _make_unicode(value, charset)
-
-
-def to_utf8(value, charset=None):
-    '''
-    Safely returns a UTF-8 version of a given string
-    >>> utils.to_utf8(u'hi')
-        'hi'
-    '''
-
-    value = _make_unicode(value, charset)
-
-    return value.encode("utf-8", "strict")
 
 
 def is_pure_ascii(value):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.5.0-rc1',
+      version='0.5.0',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.4.55',
+      version='0.5.0-rc1',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(name='flanker',
           # mime parsing (100x slower) so keep it as-is for now.
           'regex>=0.1.20110315',
           'cryptography>=0.5',
+          'ply>=3.10',
       ],
 )

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -175,3 +175,22 @@ def test_address_full_spec_non_ascii_display_name():
 
 def test_address_full_spec_non_ascii_domain():
     eq_(EmailAddress('foo <foo@экзампл.рус>').full_spec(), 'foo <foo@xn--80aniges7g.xn--p1acf>')
+
+
+def test_contains_non_ascii():
+    eq_(EmailAddress(None, 'foo@bar.com'      ).contains_non_ascii(), False)
+    eq_(EmailAddress(None, 'foo@экзампл.рус'  ).contains_non_ascii(), True)
+    eq_(EmailAddress(None, 'аджай@bar.com'    ).contains_non_ascii(), True)
+    eq_(EmailAddress(None, 'аджай@экзампл.рус').contains_non_ascii(), True)
+
+
+def test_requires_non_ascii():
+    eq_(EmailAddress(None, 'foo@bar.com'      ).requires_non_ascii(), False)
+    eq_(EmailAddress(None, 'foo@экзампл.рус'  ).requires_non_ascii(), False)
+    eq_(EmailAddress(None, 'аджай@bar.com'    ).requires_non_ascii(), True)
+    eq_(EmailAddress(None, 'аджай@экзампл.рус').requires_non_ascii(), True)
+
+
+def test_contains_domain_literal():
+    eq_(EmailAddress(None, 'foo@bar.com'  ).contains_domain_literal(), False)
+    eq_(EmailAddress(None, 'foo@[1.2.3.4]').contains_domain_literal(), True)

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -147,19 +147,6 @@ def test_display_name__to_full_spec():
         EmailAddress(u'Привет Медвед', 'foo@bar.com').full_spec())
 
 
-def test_display_name__update():
-    # Given
-    a = EmailAddress('foo bar', 'foo@bar.com')
-    eq_('foo bar <foo@bar.com>', a.full_spec())
-
-    # When
-    a.display_name = u'Привет Медвед'
-
-    # Then
-    eq_('=?utf-8?b?0J/RgNC40LLQtdGCINCc0LXQtNCy0LXQtA==?= <foo@bar.com>',
-        a.full_spec())
-
-
 def test_address_full_spec():
     eq_(EmailAddress('foo <foo@bar.com>'        ).full_spec(), 'foo <foo@bar.com>')
     eq_(EmailAddress('аджай <аджай@экзампл.рус>').full_spec(), 'аджай <аджай@экзампл.рус>')

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 
 from .. import *
-from nose.tools import assert_equal, assert_not_equal
+from nose.tools import assert_equal, assert_not_equal, assert_raises
 
 from flanker.addresslib.address import parse, parse_list
 from flanker.addresslib.address import Address, AddressList, EmailAddress, UrlAddress
@@ -160,21 +160,31 @@ def test_display_name__update():
         a.full_spec())
 
 
+def test_address_full_spec():
+    eq_(EmailAddress('foo <foo@bar.com>'        ).full_spec(), 'foo <foo@bar.com>')
+    eq_(EmailAddress('аджай <аджай@экзампл.рус>').full_spec(), 'аджай <аджай@экзампл.рус>')
+
+
 def test_address_to_unicode():
     eq_(EmailAddress('foo <foo@bar.com>'        ).to_unicode(), u'foo <foo@bar.com>')
     eq_(EmailAddress('аджай <аджай@экзампл.рус>').to_unicode(), u'аджай <аджай@экзампл.рус>')
 
 
-def test_address_full_spec():
-    eq_(EmailAddress('foo <foo@bar.com>').full_spec(), 'foo <foo@bar.com>')
+def test_address_to_ace():
+    eq_(EmailAddress('foo <foo@bar.com>').to_ace(), 'foo <foo@bar.com>')
 
 
-def test_address_full_spec_non_ascii_display_name():
-    eq_(EmailAddress('аджай <foo@bar.com>').full_spec(), '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>')
+def test_address_to_ace_non_ascii_display_name():
+    eq_(EmailAddress('аджай <foo@bar.com>').to_ace(), '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>')
 
 
-def test_address_full_spec_non_ascii_domain():
-    eq_(EmailAddress('foo <foo@экзампл.рус>').full_spec(), 'foo <foo@xn--80aniges7g.xn--p1acf>')
+def test_address_to_ace_non_ascii_domain():
+    eq_(EmailAddress('foo <foo@экзампл.рус>').to_ace(), 'foo <foo@xn--80aniges7g.xn--p1acf>')
+
+
+def test_address_to_ace_non_ascii_local_part():
+    with assert_raises(ValueError):
+        EmailAddress('foo <аджай@bar.com>').to_ace()
 
 
 def test_contains_non_ascii():

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -108,7 +108,7 @@ def test_addresslist_with_apostrophe():
     eq_(2, len(lst))
     eq_('Allan G\'o <allan@example.com>', lst[0].full_spec())
     eq_('Os Wi <oswi@example.com>', lst[1].full_spec())
-    lst = parse_list("=?UTF-8?Q?Eugueny_=CF=8E_Kontsevoy?= <eugueny@gmail.com>")
+    lst = parse_list("Eugueny ώ Kontsevoy <eugueny@gmail.com>")
     eq_('=?utf-8?q?Eugueny_=CF=8E_Kontsevoy?= <eugueny@gmail.com>', lst.full_spec())
     eq_(u'Eugueny ώ Kontsevoy', lst[0].display_name)
 

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -148,30 +148,25 @@ def test_display_name__to_full_spec():
 
 
 def test_address_full_spec():
-    eq_(EmailAddress('foo <foo@bar.com>'        ).full_spec(), 'foo <foo@bar.com>')
-    eq_(EmailAddress('аджай <аджай@экзампл.рус>').full_spec(), 'аджай <аджай@экзампл.рус>')
+    eq_(EmailAddress('foo <foo@bar.com>').full_spec(), 'foo <foo@bar.com>')
+
+
+def test_address_full_spec_non_ascii_display_name():
+    eq_(EmailAddress('аджай <foo@bar.com>').full_spec(), '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>')
+
+
+def test_address_full_spec_non_ascii_domain():
+    eq_(EmailAddress('foo <foo@экзампл.рус>').full_spec(), 'foo <foo@xn--80aniges7g.xn--p1acf>')
+
+
+def test_address_full_spec_non_ascii_local_part():
+    with assert_raises(ValueError):
+        EmailAddress('foo <аджай@bar.com>').full_spec()
 
 
 def test_address_to_unicode():
     eq_(EmailAddress('foo <foo@bar.com>'        ).to_unicode(), u'foo <foo@bar.com>')
     eq_(EmailAddress('аджай <аджай@экзампл.рус>').to_unicode(), u'аджай <аджай@экзампл.рус>')
-
-
-def test_address_to_ace():
-    eq_(EmailAddress('foo <foo@bar.com>').to_ace(), 'foo <foo@bar.com>')
-
-
-def test_address_to_ace_non_ascii_display_name():
-    eq_(EmailAddress('аджай <foo@bar.com>').to_ace(), '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>')
-
-
-def test_address_to_ace_non_ascii_domain():
-    eq_(EmailAddress('foo <foo@экзампл.рус>').to_ace(), 'foo <foo@xn--80aniges7g.xn--p1acf>')
-
-
-def test_address_to_ace_non_ascii_local_part():
-    with assert_raises(ValueError):
-        EmailAddress('foo <аджай@bar.com>').to_ace()
 
 
 def test_contains_non_ascii():

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -158,3 +158,20 @@ def test_display_name__update():
     # Then
     eq_('=?utf-8?b?0J/RgNC40LLQtdGCINCc0LXQtNCy0LXQtA==?= <foo@bar.com>',
         a.full_spec())
+
+
+def test_address_to_unicode():
+    eq_(EmailAddress('foo <foo@bar.com>'        ).to_unicode(), u'foo <foo@bar.com>')
+    eq_(EmailAddress('аджай <аджай@экзампл.рус>').to_unicode(), u'аджай <аджай@экзампл.рус>')
+
+
+def test_address_full_spec():
+    eq_(EmailAddress('foo <foo@bar.com>').full_spec(), 'foo <foo@bar.com>')
+
+
+def test_address_full_spec_non_ascii_display_name():
+    eq_(EmailAddress('аджай <foo@bar.com>').full_spec(), '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>')
+
+
+def test_address_full_spec_non_ascii_domain():
+    eq_(EmailAddress('foo <foo@экзампл.рус>').full_spec(), 'foo <foo@xn--80aniges7g.xn--p1acf>')

--- a/tests/addresslib/metrics_test.py
+++ b/tests/addresslib/metrics_test.py
@@ -5,7 +5,7 @@ from mock import patch
 from nose.tools import assert_equal, assert_not_equal
 from nose.tools import nottest
 
-from flanker.addresslib import address, validate
+from flanker.addresslib import address
 
 @nottest
 def mock_exchanger_lookup(arg, metrics=False):
@@ -40,7 +40,7 @@ def test_metrics_parse_list():
 
 def test_metrics_validate_address():
     # validate
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         assert_equal(len(address.validate_address('foo@mailgun.net', metrics=True)), 2)
@@ -55,7 +55,7 @@ def test_metrics_validate_address():
 
 def test_metrics_validate_list():
     # validate_list
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         assert_equal(len(address.validate_list('foo@mailgun.org, bar@mailgun.org', metrics=True)), 2)

--- a/tests/addresslib/parser_address_list_test.py
+++ b/tests/addresslib/parser_address_list_test.py
@@ -5,8 +5,7 @@ from itertools import chain, combinations, permutations
 from nose.tools import assert_equal, assert_not_equal
 from nose.tools import nottest
 
-from flanker.addresslib import address
-from flanker.addresslib.address import EmailAddress, AddressList
+from flanker.addresslib.address import EmailAddress, AddressList, parse_list
 
 
 @nottest
@@ -16,14 +15,8 @@ def powerset(iterable):
     return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
 
 @nottest
-def run_relaxed_test(string, expected_mlist, expected_unpar):
-    mlist, unpar = address.parse_list(string, strict=False, as_tuple=True)
-    assert_equal(mlist, expected_mlist)
-    assert_equal(unpar, expected_unpar)
-
-@nottest
-def run_strict_test(string, expected_mlist):
-    mlist = address.parse_list(string, strict=True)
+def run_test(string, expected_mlist):
+    mlist = parse_list(string)
     assert_equal(mlist, expected_mlist)
 
 
@@ -38,13 +31,12 @@ LINUS_MBX = EmailAddress('Linus Torvalds', 'torvalds@kernel.org')
 
 def test_sanity():
     addr_string = 'Bill Gates <bill@microsoft.com>, Steve Jobs <steve@apple.com>; torvalds@kernel.org'
-    run_relaxed_test(addr_string, [BILL_MBX, STEVE_MBX, LINUS_AS], [])
-    run_strict_test(addr_string,  [BILL_MBX, STEVE_MBX, LINUS_AS])
+    run_test(addr_string,  [BILL_MBX, STEVE_MBX, LINUS_AS])
 
 
 def test_simple_valid():
     s = '''http://foo.com:8080; "Ev K." <ev@host.com>, "Alex K" alex@yahoo.net, "Tom, S" "tom+[a]"@s.com'''
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(4, len(addrs))
 
@@ -69,7 +61,7 @@ def test_simple_valid():
 
 
     s = '''"Allan G\'o"  <allan@example.com>, "Os Wi" <oswi@example.com>'''
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(2, len(addrs))
 
@@ -85,7 +77,7 @@ def test_simple_valid():
 
 
     s = u'''I am also A <a@HOST.com>, Zeka <EV@host.coM> ;Gonzalo Bañuelos<gonz@host.com>'''
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(3, len(addrs))
 
@@ -106,7 +98,7 @@ def test_simple_valid():
 
 
     s = r'''"Escaped" "\e\s\c\a\p\e\d"@sld.com; http://userid:password@example.com:8080, "Dmitry" <my|'`!#_~%$&{}?^+-*@host.com>'''
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(3, len(addrs))
 
@@ -126,7 +118,7 @@ def test_simple_valid():
 
 
     s = "http://foo.com/blah_blah_(wikipedia)"
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(1, len(addrs))
 
@@ -136,7 +128,7 @@ def test_simple_valid():
 
 
     s = "Sasha Klizhentas <klizhentas@gmail.com>"
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(1, len(addrs))
 
@@ -147,7 +139,7 @@ def test_simple_valid():
 
 
     s = "admin@mailgunhq.com,lift@example.com"
-    addrs = address.parse_list(s)
+    addrs = parse_list(s)
 
     assert_equal(2, len(addrs))
 
@@ -164,44 +156,33 @@ def test_simple_valid():
 
 def test_simple_invalid():
     s = '''httd://foo.com:8080\r\n; "Ev K." <ev@ host.com>\n "Alex K" alex@ , "Tom, S" "tom+["  a]"@s.com'''
-    assert_equal(address.AddressList(), address.parse_list(s))
+    assert_equal(AddressList(), parse_list(s))
 
     s = ""
-    assert_equal(address.AddressList(), address.parse_list(s))
+    assert_equal(AddressList(), parse_list(s))
 
     s = "crap"
-    assert_equal(address.AddressList(), address.parse_list(s))
+    assert_equal(AddressList(), parse_list(s))
 
 
 def test_endpoints():
     # expected result: [foo@example.com, baz@example.com]
-    presult = address.parse_list('foo@example.com, bar, baz@example.com', strict=False, as_tuple=False)
+    presult = parse_list('foo@example.com, bar, baz@example.com', as_tuple=False)
     assert isinstance(presult, AddressList)
-    assert_equal(2, len(presult))
+    assert_equal(0, len(presult))
 
     # expected result: ([foo@example.com, baz@example.com], ['bar'])
-    presult = address.parse_list('foo@example.com, bar, baz@example.com', strict=False, as_tuple=True)
+    presult = parse_list(['foo@example.com', 'bar', 'baz@example.com'], as_tuple=True)
     assert type(presult) is tuple
     assert_equal(2, len(presult[0]))
     assert_equal(1, len(presult[1]))
 
-    # expected result: [foo@example.com]
-    presult = address.parse_list('foo@example.com, bar, baz@example.com', strict=True, as_tuple=False)
-    assert isinstance(presult, AddressList)
-    assert_equal(1, len(presult))
 
-    # expected result: ([foo@example.com], [])
-    presult = address.parse_list('foo@example.com, bar, baz@example.com', strict=True, as_tuple=True)
-    assert type(presult) is tuple
-    assert_equal(1, len(presult[0]))
-    assert_equal(0, len(presult[1]))
-
-
-def test_delimiters_relaxed():
+def test_delimiters():
     # permutations
     for e in permutations('  ,,;;'):
         addr_string = 'bill@microsoft.com' + ''.join(e) + 'steve@apple.com, torvalds@kernel.org'
-        run_relaxed_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS], [])
+        run_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS])
 
     # powerset
     for e in powerset('  ,,;;'):
@@ -210,64 +191,4 @@ def test_delimiters_relaxed():
             continue
 
         addr_string = 'bill@microsoft.com' + ''.join(e) + 'steve@apple.com, torvalds@kernel.org'
-        run_relaxed_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS], [])
-
-def test_delimiters_strict():
-    # permutations
-    for e in permutations('  ,,;;'):
-        addr_string = 'bill@microsoft.com' + ''.join(e) + 'steve@apple.com, torvalds@kernel.org'
-        run_strict_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS])
-
-    # powerset
-    for e in powerset('  ,,;;'):
-        # empty sets will be tested by the synchronize tests
-        if ''.join(e).strip() == '':
-            continue
-
-        addr_string = 'bill@microsoft.com' + ''.join(e) + 'steve@apple.com, torvalds@kernel.org'
-        run_strict_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS])
-
-
-def test_synchronize_relaxed():
-    run_relaxed_test('"@microsoft.com, steve@apple.com', [STEVE_AS], ['"@microsoft.com'])
-    run_relaxed_test('"@microsoft.com steve@apple.com', [], ['"@microsoft.com steve@apple.com'])
-    run_relaxed_test('"@microsoft.comsteve@apple.com', [], ['"@microsoft.comsteve@apple.com'])
-
-    run_relaxed_test('bill@microsoft.com, steve, torvalds@kernel.org', [BILL_AS, LINUS_AS], ['steve'])
-    run_relaxed_test('bill@microsoft.com, steve torvalds', [BILL_AS], ['steve torvalds'])
-
-    run_relaxed_test('bill;  ', [], ['bill'])
-    run_relaxed_test('bill ;', [], ['bill '])
-    run_relaxed_test('bill ; ', [], ['bill '])
-
-    run_relaxed_test('bill@microsoft.com;  ', [BILL_AS],  [])
-    run_relaxed_test('bill@microsoft.com ;', [BILL_AS], [])
-    run_relaxed_test('bill@microsoft.com ; ', [BILL_AS], [] )
-
-    run_relaxed_test('bill; steve; linus', [], ['bill', 'steve', 'linus'])
-
-    run_relaxed_test(',;@microsoft.com, steve@apple.com', [STEVE_AS], ['@microsoft.com'])
-    run_relaxed_test(',;"@microsoft.comsteve@apple.com', [], ['"@microsoft.comsteve@apple.com'])
-
-
-def test_synchronize_strict():
-    run_strict_test('"@microsoft.com, steve@apple.com', [])
-    run_strict_test('"@microsoft.com steve@apple.com', [])
-    run_strict_test('"@microsoft.comsteve@apple.com', [])
-
-    run_strict_test('bill@microsoft.com, steve, torvalds@kernel.org', [BILL_AS])
-    run_strict_test('bill@microsoft.com, steve torvalds', [BILL_AS])
-
-    run_strict_test('bill;  ', [])
-    run_strict_test('bill ;', [])
-    run_strict_test('bill ; ', [])
-
-    run_strict_test('bill@microsoft.com;  ', [BILL_AS])
-    run_strict_test('bill@microsoft.com ;', [BILL_AS])
-    run_strict_test('bill@microsoft.com ; ', [BILL_AS])
-
-    run_strict_test('bill; steve; linus', [])
-
-    run_strict_test(',;@microsoft.com, steve@apple.com', [])
-    run_strict_test('",;@microsoft.com steve@apple.com', [])
-    run_strict_test(',;"@microsoft.comsteve@apple.com', [])
+        run_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS])

--- a/tests/addresslib/plugins/aol_test.py
+++ b/tests/addresslib/plugins/aol_test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 from flanker.addresslib import address
-from flanker.addresslib import validate
 
 from mock import patch
 from nose.tools import assert_equal, assert_not_equal
@@ -37,7 +36,7 @@ def test_exchanger_lookup():
 
 
 def test_aol_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # valid length range
@@ -72,7 +71,7 @@ def test_aol_pass():
 
 
 def test_aol_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range

--- a/tests/addresslib/plugins/gmail_test.py
+++ b/tests/addresslib/plugins/gmail_test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 from flanker.addresslib import address
-from flanker.addresslib import validate
 
 from mock import patch
 from nose.tools import assert_equal, assert_not_equal
@@ -38,7 +37,7 @@ def test_exchanger_lookup():
 
 
 def test_gmail_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # valid length range
@@ -77,7 +76,7 @@ def test_gmail_pass():
 
 
 def test_gmail_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range

--- a/tests/addresslib/plugins/google_test.py
+++ b/tests/addresslib/plugins/google_test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 from flanker.addresslib import address
-from flanker.addresslib import validate
 
 from mock import patch
 from nose.tools import assert_equal, assert_not_equal
@@ -38,7 +37,7 @@ def test_exchanger_lookup():
 
 
 def test_google_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # if single character, must be alphanum, underscore, or apostrophe
@@ -78,7 +77,7 @@ def test_google_pass():
 
 
 def test_google_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid single character (must be alphanum, underscore, or apostrophe)

--- a/tests/addresslib/plugins/hotmail_test.py
+++ b/tests/addresslib/plugins/hotmail_test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 from flanker.addresslib import address
-from flanker.addresslib import validate
 
 from mock import patch
 from nose.tools import assert_equal, assert_not_equal
@@ -37,7 +36,7 @@ def test_exchanger_lookup():
 
 
 def test_hotmail_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # valid length range
@@ -77,7 +76,7 @@ def test_hotmail_pass():
 
 
 def test_hotmail_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range

--- a/tests/addresslib/plugins/icloud_test.py
+++ b/tests/addresslib/plugins/icloud_test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 from flanker.addresslib import address
-from flanker.addresslib import validate
 
 from mock import patch
 from nose.tools import assert_equal, assert_not_equal
@@ -37,7 +36,7 @@ def test_exchanger_lookup():
 
 
 def test_icloud_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # valid length range
@@ -81,7 +80,7 @@ def test_icloud_pass():
 
 
 def test_icloud_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range

--- a/tests/addresslib/plugins/yahoo_test.py
+++ b/tests/addresslib/plugins/yahoo_test.py
@@ -4,7 +4,6 @@ import random
 import string
 
 from flanker.addresslib import address
-from flanker.addresslib import validate
 
 from mock import patch
 from nose.tools import assert_equal, assert_not_equal
@@ -37,7 +36,7 @@ def test_exchanger_lookup():
 
 
 def test_yahoo_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # valid length range
@@ -72,7 +71,7 @@ def test_yahoo_pass():
 
 
 def test_yahoo_disposable_pass():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # valid length range
@@ -97,7 +96,7 @@ def test_yahoo_disposable_pass():
 
 
 def test_yahoo_disposable_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid base length range
@@ -130,7 +129,7 @@ def test_yahoo_disposable_fail():
             assert_equal(addr, None)
 
 def test_yahoo_fail():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range

--- a/tests/addresslib/validator_test.py
+++ b/tests/addresslib/validator_test.py
@@ -164,23 +164,23 @@ def test_parse_syntax_only_false():
         assert_equal(unpar, [])
 
         # all invalid
-        parse, unpar = address.validate_list(', '.join(invalid_mx_list), as_tuple=True)
+        parse, unpar = address.validate_list(invalid_mx_list, as_tuple=True)
         assert_equal(parse, [])
         assert_equal(unpar, invalid_mx_list)
 
-        parse, unpar = address.validate_list(', '.join(invalid_tld_list), as_tuple=True)
+        parse, unpar = address.validate_list(invalid_tld_list, as_tuple=True)
         assert_equal(parse, [])
         assert_equal(unpar, invalid_tld_list)
 
-        parse, unpar = address.validate_list(', '.join(invalid_domain_list), as_tuple=True)
+        parse, unpar = address.validate_list(invalid_domain_list, as_tuple=True)
         assert_equal(parse, [])
         assert_equal(unpar, invalid_domain_list)
 
-        parse, unpar = address.validate_list(', '.join(invalid_subdomain_list), as_tuple=True)
+        parse, unpar = address.validate_list(invalid_subdomain_list, as_tuple=True)
         assert_equal(parse, [])
         assert_equal(unpar, invalid_subdomain_list)
 
-        parse, unpar = address.validate_list(', '.join(all_list), as_tuple=True)
+        parse, unpar = address.validate_list(all_list, as_tuple=True)
         assert_equal(parse, all_valid_list)
         assert_equal(unpar, all_invalid_list)
 

--- a/tests/addresslib/validator_test.py
+++ b/tests/addresslib/validator_test.py
@@ -8,8 +8,7 @@ from nose.tools import assert_equal, assert_not_equal
 from nose.tools import nottest
 from mock import patch
 
-from flanker.addresslib import address
-from flanker.addresslib import validate
+from flanker.addresslib import address, validate
 
 
 COMMENT = re.compile(r'''\s*#''')
@@ -82,7 +81,7 @@ def test_abridged_mailbox_valid_set():
             continue
 
         # mocked valid dns lookup for tests
-        with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+        with patch.object(address, 'mail_exchanger_lookup') as mock_method:
             mock_method.side_effect = mock_exchanger_lookup
 
             addr = line + '@ai'
@@ -113,7 +112,7 @@ def test_abridged_mailbox_invalid_set():
             continue
 
         # mocked valid dns lookup for tests
-        with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+        with patch.object(address, 'mail_exchanger_lookup') as mock_method:
             mock_method.side_effect = mock_exchanger_lookup
 
             addr = line + '@ai'
@@ -148,7 +147,7 @@ def test_parse_syntax_only_false():
     all_list = all_valid_list + all_invalid_list
 
     # all valid
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         parse, unpar = address.validate_list(', '.join(valid_tld_list), as_tuple=True)
@@ -231,7 +230,7 @@ def test_mx_lookup_metrics():
         a = validate.mail_exchanger_lookup('example.com', metrics=False)
 
 def test_validate_address_metrics():
-    with patch.object(validate, 'mail_exchanger_lookup') as mock_method:
+    with patch.object(address, 'mail_exchanger_lookup') as mock_method:
         mock_method.side_effect = mock_exchanger_lookup
 
         parse, metrics = address.validate_address('foo@example.com', metrics=True)

--- a/tests/addresslib/validator_test.py
+++ b/tests/addresslib/validator_test.py
@@ -240,3 +240,17 @@ def test_validate_address_metrics():
         assert_equal(metrics['mx_lookup'], 10)
         assert_equal(metrics['dns_lookup'], 20)
         assert_equal(metrics['mx_conn'], 30)
+
+
+@patch('flanker.addresslib.validate.connect_to_mail_exchanger')
+@patch('flanker.addresslib.validate.lookup_domain')
+@patch('flanker.addresslib.validate.lookup_exchanger_in_cache')
+def test_validate_domain_literal(mock_lookup_exchanger_in_cache, mock_lookup_domain, mock_connect_to_mail_exchanger):
+    mock_lookup_exchanger_in_cache.return_value = (False, None)
+    mock_connect_to_mail_exchanger.return_value = '1.2.3.4'
+
+    addr = address.validate_address('foo@[1.2.3.4]')
+
+    assert_equal(addr.full_spec(), 'foo@[1.2.3.4]')
+    mock_lookup_domain.assert_not_called()
+    mock_connect_to_mail_exchanger.assert_called_once_with(['1.2.3.4'])

--- a/tests/fixtures/abridged_localpart_invalid.txt
+++ b/tests/fixtures/abridged_localpart_invalid.txt
@@ -24,11 +24,9 @@ ote"
 @
 a"bcd,e:f;g<h>i[j\k]l
 a"bcde:fg<h>i[j\k]l
-just"not"right
 this is"not\allowed
 this\ still\"not\\allowed
 partially."quoted"
-just"not"right
 this is"not\allowed
 this\ still\"not\\allowed
 .first.last
@@ -39,7 +37,6 @@ first..last
 "\"
 abc\
 Doug\ \"Ace\"\ Lovell
-"Doug "Ace" L."
 Doug\ \"Ace\"\ L\.
 abc\
 [test]

--- a/tests/fixtures/mailbox_invalid.txt
+++ b/tests/fixtures/mailbox_invalid.txt
@@ -15,7 +15,6 @@ missing-at-sign.net
 Abc.example.com
 A@b@c@example.com
 a"b(c)d,e:f;g<h>i[j\k]l@example.com
-just"not"right@example.com
 this is"not\allowed@example.com
 this\ still\"not\\allowed@example.com
 first.last@sub.do,com
@@ -35,20 +34,6 @@ first..last@iana.org
                                                                                         # Which allows "" as a local-part for a addr-spec
 first\@last@iana.org
 first.last@
-first.last@[.12.34.56.78]
-first.last@[12.34.56.789]
-first.last@[::12.34.56.78]
-first.last@[IPv5:::12.34.56.78]
-first.last@[IPv6:1111:2222:3333:4444:5555:12.34.56.78]
-first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:12.34.56.78]
-first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777]
-first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]
-first.last@[IPv6:1111:2222::3333::4444:5555:6666]
-first.last@[IPv6:1111:2222:333x::4444:5555]
-first.last@[IPv6:1111:2222:33333::4444:5555]
-first.last@-xample.com
-first.last@exampl-.com
-first.last@x234567890123456789012345678901234567890123456789012345678901234.iana.org
 abc\@def@iana.org
 abc\@iana.org
 Doug\ \"Ace\"\ Lovell@iana.org
@@ -62,7 +47,6 @@ ote"@iana.org
 .dot@iana.org
 dot.@iana.org
 two..dot@iana.org
-"Doug "Ace" L."@iana.org
 Doug\ \"Ace\"\ L\.@iana.org
 hello world@iana.org                                                                    # lax parser picks up "hello" as display-name
 gatsby@f.sc.ot.t.f.i.tzg.era.l.d.
@@ -96,7 +80,6 @@ first\last@iana.org
 Abc\@def@iana.org
 #Fred\ Bloggs@iana.org                                                                  # people use backslash all the time
 Joe.\Blow@iana.org
-first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.567.89]
 {^c\@**Dog^}@cartoon.com
 "foo"(yay)@(hoopla)[1.2.3.4]
 cal(foo(bar)@iamcal.com
@@ -111,13 +94,9 @@ aaa.com
 aaa@.com
 aaa@.123
 aaa@[123.123.123.123]a
-aaa@[123.123.123.333]
 a@bar.com.
-a@-b.com
-a@b-.com
 -@..com
 -@a..com
-invalid@about.museum-
 test@...........com
 # first.last@[IPv6::]                                                                   # domain literal
 # first.last@[IPv6::::]                                                                 # domain literal

--- a/tests/fixtures/mailbox_valid.txt
+++ b/tests/fixtures/mailbox_valid.txt
@@ -198,3 +198,20 @@ cdburgess+!#$%&'*-/=?+_{}|~test@mail.com
 test@test.com
 test@xn--example.com
 test@example.com
+
+#
+# Sample valid international email addresses from https://en.wikipedia.org/wiki/International_email
+#
+Abc@example.com
+Abc.123@example.com
+user+mailbox/department=shipping@example.com
+!#$%&'*+-/=?^_`.{|}~@example.com
+"Abc@def"@example.com
+"Fred Bloggs"@example.com
+"Joe.\\Blow"@example.com
+用户@例子.广告
+उपयोगकर्ता@उदाहरण.कॉम
+юзер@екзампл.ком
+θσερ@εχαμπλε.ψομ
+Dörte@Sörensen.example.com
+аджай@экзампл.рус

--- a/tests/mime/message/headers/encodedword_test.py
+++ b/tests/mime/message/headers/encodedword_test.py
@@ -3,7 +3,7 @@
 from nose.tools import *
 from mock import *
 from flanker.mime.message.headers import encodedword
-from flanker import utils
+from flanker.mime.message import utils
 from flanker.mime.message import errors, charsets
 
 def encoded_word_test():


### PR DESCRIPTION
This PR adds support for non-ASCII characters in the local and domain parts of email addresses and domain literals for the domain part. It completely rewrites the lexer and parser based on [Ply](https://github.com/dabeaz/ply) and heavily refactors of the address module. The previous lexer module, `tokenizer.py`, is kept because some of the domain specific validations use it. Those should be the subject of a later PR.

As far as I'm aware, the public interfaces in the address module should be unchanged and all the addresses that validated previously should still validate properly.

The only potentially breaking change is that I've removed the relaxed vs. strict parsing of mailing lists. The trade-off for having a more flexible parser is that we can't make as many assumptions about an unparsable list. `parse_list()` can still return a tuple of parsed and unparsed addresses but only if the input is a list of discrete addresses. It's up to services that use this module to either format user input into a list or return an appropriate error to the user so that they can reformat and resubmit the list.

I've also added a debug terminal to `parser.py` that can be invoked with `python flanker/addresslib/parser.py`. Given an address it will show the list of tokens, parsing behaviour, and final result. Sample output:
```
flanker> foo@bar.com

Tokens list:

LexToken(ATEXT,'foo',1,0)
LexToken(AT,'@',1,3)
LexToken(ATEXT,'bar',1,4)
LexToken(DOT,'.',1,7)
LexToken(ATEXT,'com',1,8)

Parsing behavior:

INFO:__main__:PLY: PARSE DEBUG START
INFO:__main__:Action : Reduce rule [ofwsp -> <empty>] with [] and goto state 3
INFO:__main__:Result : <str @ 0x7f89b88e6508> ('')
INFO:__main__:Action : Reduce rule [ofwsp -> <empty>] with [] and goto state 42
INFO:__main__:Result : <str @ 0x7f89b88e6508> ('')
INFO:__main__:Action : Reduce rule [atom -> ofwsp ATEXT ofwsp] with ['','foo',''] and goto state 11
INFO:__main__:Result : <str @ 0x7f89b002aaa8> ('foo')
INFO:__main__:Action : Reduce rule [local_part -> atom] with ['foo'] and goto state 6
INFO:__main__:Result : <str @ 0x7f89b002aaa8> ('foo')
INFO:__main__:Action : Reduce rule [ofwsp -> <empty>] with [] and goto state 44
INFO:__main__:Result : <str @ 0x7f89b88e6508> ('')
INFO:__main__:Action : Reduce rule [dot_atom_text -> ATEXT DOT ATEXT] with ['bar','.','com'] and goto state 19
INFO:__main__:Result : <str @ 0x7f89afb70f00> ('bar.com')
INFO:__main__:Action : Reduce rule [ofwsp -> <empty>] with [] and goto state 39
INFO:__main__:Result : <str @ 0x7f89b88e6508> ('')
INFO:__main__:Action : Reduce rule [dot_atom -> ofwsp dot_atom_text ofwsp] with ['','bar.com',''] and goto state 45
INFO:__main__:Result : <str @ 0x7f89afb70f00> ('bar.com')
INFO:__main__:Action : Reduce rule [domain -> dot_atom] with ['bar.com'] and goto state 43
INFO:__main__:Result : <str @ 0x7f89afb70f00> ('bar.com')
INFO:__main__:Action : Reduce rule [addr_spec -> local_part AT domain] with ['foo','@','bar.com'] and goto state 7
INFO:__main__:Result : <Mailbox @ 0x7f89afb6af70> (Mailbox(display_name='', local_part='foo ...)
INFO:__main__:Action : Reduce rule [mailbox -> addr_spec] with [<Mailbox @ 0x7f89afb6af70>] and goto state 9
INFO:__main__:Result : <Mailbox @ 0x7f89afb6af70> (Mailbox(display_name='', local_part='foo ...)
INFO:__main__:Action : Reduce rule [mailbox_or_url -> mailbox] with [<Mailbox @ 0x7f89afb6af70>] and goto state 8
INFO:__main__:Result : <Mailbox @ 0x7f89afb6af70> (Mailbox(display_name='', local_part='foo ...)
INFO:__main__:Action : Reduce rule [mailbox_or_url_list -> mailbox_or_url] with [<Mailbox @ 0x7f89afb6af70>] and goto state 13
INFO:__main__:Result : <list @ 0x7f89afb830e0> ([Mailbox(display_name='', local_part='fo ...)
INFO:__main__:Done   : Returning <list @ 0x7f89afb830e0> ([Mailbox(display_name='', local_part='fo ...)
INFO:__main__:PLY: PARSE DEBUG END

Result:

[Mailbox(display_name='', local_part='foo', domain='bar.com')]
```