### PR TITLE
Allow dot/full-stop in display name

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -98,7 +98,7 @@ def parse(address, addr_spec_only=False, metrics=False):
 
     try:
         bstart = time()
-        retval = _lift_parser_result(parser.parse(address, lexer=lexer.clone()))
+        retval = _lift_parser_result(parser.parse(address.strip(), lexer=lexer.clone()))
         mtimes['parsing'] = time() - bstart
     except (LexError, YaccError, SyntaxError):
         log.warning('Failed to parse address: %s',
@@ -146,7 +146,7 @@ def parse_discrete_list(address_list, metrics=False):
 
     try:
         bstart = time()
-        retval = _lift_parser_result(parser.parse(address_list, lexer=lexer.clone()))
+        retval = _lift_parser_result(parser.parse(address_list.strip(), lexer=lexer.clone()))
         mtimes['parsing'] = time() - bstart
     except (LexError, YaccError, SyntaxError):
         log.warning('Failed to parse address list: %s',
@@ -437,7 +437,7 @@ class EmailAddress(Address):
         if raw_display_name and raw_addr_spec:
 
             parser = addr_spec_parser
-            mailbox = parser.parse(raw_addr_spec, lexer=lexer.clone())
+            mailbox = parser.parse(raw_addr_spec.strip(), lexer=lexer.clone())
 
             self._display_name = raw_display_name
             self._mailbox = mailbox.local_part
@@ -446,7 +446,7 @@ class EmailAddress(Address):
         elif raw_display_name:
 
             parser = mailbox_parser
-            mailbox = parser.parse(raw_display_name, lexer=lexer.clone())
+            mailbox = parser.parse(raw_display_name.strip(), lexer=lexer.clone())
 
             self._display_name = mailbox.display_name
             self._mailbox = mailbox.local_part
@@ -455,7 +455,7 @@ class EmailAddress(Address):
         elif raw_addr_spec:
 
             parser = addr_spec_parser
-            mailbox = parser.parse(raw_addr_spec, lexer=lexer.clone())
+            mailbox = parser.parse(raw_addr_spec.strip(), lexer=lexer.clone())
 
             self._display_name = ''
             self._mailbox = mailbox.local_part
@@ -621,7 +621,7 @@ class UrlAddress(Address):
             if isinstance(raw, unicode):
                 raw = raw.encode('utf-8')
             parser = url_parser
-            url = parser.parse(raw, lexer=lexer.clone())
+            url = parser.parse(raw.strip(), lexer=lexer.clone())
             self._address = urlparse(url.address)
         elif address:
             self._address = urlparse(address)

--- a/flanker/addresslib/parser.py
+++ b/flanker/addresslib/parser.py
@@ -16,13 +16,6 @@ Url     = namedtuple('Url',     ['address'])
 
 start = 'mailbox_or_url_list'
 
-precedence = (
-    ('left', 'FWSP', 'ATEXT', 'QTEXT', 'QPAIR', 'DTEXT'),
-    ('left', 'DOT', 'AT'),
-    ('left', 'RANGLE', 'RBRACKET', 'DQUOTE'),
-    ('left', 'COMMA', 'SEMICOLON'),
-)
-
 def p_expression_mailbox_or_url_list(p):
     '''mailbox_or_url_list : mailbox_or_url_list delim mailbox_or_url
                            | mailbox_or_url_list delim
@@ -36,8 +29,8 @@ def p_expression_mailbox_or_url_list(p):
 
 def p_expression_delim(p):
     '''delim : delim delim
-             | COMMA ofwsp
-             | SEMICOLON ofwsp'''
+             | ofwsp COMMA ofwsp
+             | ofwsp SEMICOLON ofwsp'''
 
 def p_expression_mailbox_or_url(p):
     '''mailbox_or_url : mailbox
@@ -45,43 +38,38 @@ def p_expression_mailbox_or_url(p):
     p[0] = p[1]
 
 def p_expression_url(p):
-    'url : ofwsp URL ofwsp'
-    p[0] = Url(p[2])
+    'url : URL'
+    p[0] = Url(p[1])
 
 def p_expression_mailbox(p):
     '''mailbox : addr_spec
-               | name_addr
-               | angle_addr''' # NOTE: `angle_addr` is invalid here but has been added for backwards compatability
+               | name_addr'''
     p[0] = p[1]
 
 def p_expression_name_addr(p):
-    '''name_addr : phrase angle_addr
-                 | phrase addr_spec''' # NOTE: `phrase addr_spec` is invalid here but has been added for backwards compatability
-    p[0] = Mailbox(p[1], p[2].local_part, p[2].domain)
+    'name_addr : phrase angle_addr'
+    p[0] = Mailbox(' '.join(p[1].split()), p[2].local_part, p[2].domain)
 
 def p_expression_angle_addr(p):
-    'angle_addr : ofwsp LANGLE addr_spec RANGLE ofwsp'
-    p[0] = p[3]
+    'angle_addr : LANGLE ofwsp addr_spec ofwsp RANGLE'
+    p[0] = Mailbox('', p[3].local_part, p[3].domain)
 
 def p_expression_addr_spec(p):
-    '''addr_spec : local_part AT domain'''
+    '''addr_spec : DOT_ATOM      AT DOT_ATOM
+                 | DOT_ATOM      AT ATOM
+                 | DOT_ATOM      AT domain_literal
+                 | ATOM          AT DOT_ATOM
+                 | ATOM          AT ATOM
+                 | ATOM          AT domain_literal
+                 | quoted_string AT DOT_ATOM
+                 | quoted_string AT ATOM
+                 | quoted_string AT domain_literal
+    '''
     p[0] = Mailbox('', p[1], p[3])
 
-def p_expression_local_part(p):
-    '''local_part : dot_atom
-                  | atom
-                  | quoted_string'''
-    p[0] = p[1]
-
-def p_expression_domain(p):
-    '''domain : dot_atom
-              | atom
-              | domain_literal'''
-    p[0] = p[1]
-
 def p_expression_quoted_string(p):
-    '''quoted_string : ofwsp DQUOTE quoted_string_text DQUOTE ofwsp'''
-    p[0] = '"{}"'.format(p[3])
+    '''quoted_string : DQUOTE quoted_string_text DQUOTE'''
+    p[0] = '"{}"'.format(p[2])
 
 def p_expression_quoted_string_text(p):
     '''quoted_string_text : quoted_string_text QTEXT
@@ -99,8 +87,8 @@ def p_expression_quoted_string_text(p):
         p[0] = ''
 
 def p_expression_domain_literal(p):
-    '''domain_literal : ofwsp LBRACKET domain_literal_text RBRACKET ofwsp'''
-    p[0] = '[{}]'.format(p[3])
+    '''domain_literal : LBRACKET domain_literal_text RBRACKET'''
+    p[0] = '[{}]'.format(p[2])
 
 def p_expression_domain_literal_text(p):
     '''domain_literal_text : domain_literal_text DTEXT
@@ -113,32 +101,19 @@ def p_expression_domain_literal_text(p):
         p[0] = p[1]
 
 def p_expression_phrase(p):
-    '''phrase : phrase atom
+    '''phrase : phrase ATOM
+              | phrase DOT_ATOM
+              | phrase DOT
               | phrase quoted_string
-              | atom
+              | phrase fwsp
+              | ATOM
+              | DOT_ATOM
+              | DOT
               | quoted_string'''
     if len(p) == 3:
-        p[0] = '{} {}'.format(p[1], p[2])
+        p[0] = '{}{}'.format(p[1], p[2])
     elif len(p) == 2:
         p[0] = p[1]
-
-# NOTE: Our expression for dot_atom here differs from RFC 5322. In the RFC
-# dot_atom is expressed as a superset of atom. That makes it difficult to write
-# unambiguous parsing rules so we've defined it here in such a way that it
-# doesn't conflict. As a result, any higher order rules that accept dot_atom
-# should also accept atom.
-def p_expression_dot_atom(p):
-    'dot_atom : ofwsp dot_atom_text ofwsp'
-    p[0] = p[2]
-
-def p_expression_dot_atom_text(p):
-    '''dot_atom_text : dot_atom_text DOT ATEXT
-                     | ATEXT DOT ATEXT'''
-    p[0] = '{}.{}'.format(p[1], p[3])
-
-def p_expression_atom(p):
-    'atom : ofwsp ATEXT ofwsp'
-    p[0] = p[2]
 
 def p_expression_ofwsp(p):
     '''ofwsp : fwsp

--- a/flanker/addresslib/parser.py
+++ b/flanker/addresslib/parser.py
@@ -68,8 +68,12 @@ def p_expression_domain(p):
     p[0] = p[1]
 
 def p_expression_quoted_string(p):
-    '''quoted_string : DQUOTE quoted_string_text DQUOTE'''
-    p[0] = '"{}"'.format(p[2])
+    '''quoted_string : DQUOTE quoted_string_text DQUOTE
+                     | DQUOTE DQUOTE'''
+    if len(p) == 4:
+        p[0] = '"{}"'.format(p[2])
+    elif len(p) == 3:
+        p[0] = '""'
 
 def p_expression_quoted_string_text(p):
     '''quoted_string_text : quoted_string_text QTEXT
@@ -77,18 +81,19 @@ def p_expression_quoted_string_text(p):
                           | quoted_string_text fwsp
                           | QTEXT
                           | QPAIR
-                          | fwsp
-                          |''' # NOTE: `empty` is invalid but has been added for backwards compatability
+                          | fwsp'''
     if len(p) == 3:
         p[0] = '{}{}'.format(p[1], p[2])
     elif len(p) == 2:
         p[0] = p[1]
-    elif len(p) == 1:
-        p[0] = ''
 
 def p_expression_domain_literal(p):
-    '''domain_literal : LBRACKET domain_literal_text RBRACKET'''
-    p[0] = '[{}]'.format(p[2])
+    '''domain_literal : LBRACKET domain_literal_text RBRACKET
+                      | LBRACKET RBRACKET'''
+    if len(p) == 4:
+        p[0] = '[{}]'.format(p[2])
+    elif len(p) == 3:
+        p[0] = '[]'
 
 def p_expression_domain_literal_text(p):
     '''domain_literal_text : domain_literal_text DTEXT

--- a/flanker/addresslib/quote.py
+++ b/flanker/addresslib/quote.py
@@ -1,9 +1,9 @@
 from StringIO import StringIO
 import re
-from flanker.addresslib.lexer import t_ATEXT, t_FWSP
+from flanker.addresslib.lexer import t_ATOM, t_FWSP
 
 _RE_ATOM_PHRASE = re.compile(
-    r'({atext}({fwsp}{atext})*)?'.format(atext=t_ATEXT, fwsp=t_FWSP),
+    r'({atom}({fwsp}{atom})*)?'.format(atom=t_ATOM, fwsp=t_FWSP),
     re.MULTILINE | re.VERBOSE)
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.6',
+      version='0.6.7',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -72,7 +72,7 @@ def test_addresslist_basics():
     ok_("Biz@kontsevoy.com" in str(lst))
 
     # check parsing:
-    spec = '''http://foo.com:8080, "Ev K." <ev@host.com>, "Alex K" alex@yahoo.net; "Tom, S" "tom+[a]"@s.com'''
+    spec = '''http://foo.com:8080, "Ev K." <ev@host.com>, "Alex K" <alex@yahoo.net>; "Tom, S" <"tom+[a]"@s.com>'''
     lst = parse_list(spec, True)
 
     eq_(len(lst), 4)
@@ -164,7 +164,7 @@ def test_views():
         'full_spec': ValueError(),
     }, {
         # UTF-8
-        'addr': parse(u'"Федот" стрелец@письмо.рф'),
+        'addr': parse(u'"Федот" <стрелец@письмо.рф>'),
         'repr': 'Федот <стрелец@письмо.рф>',
         'str': 'стрелец@письмо.рф',
         'unicode': u'Федот <стрелец@письмо.рф>',
@@ -192,7 +192,7 @@ def test_views():
         'full_spec': ValueError(),
     }, {
         # UTF-8 address list
-        'addr': parse_list(u'"Федот" стрелец@письмо.рф, Марья <искусница@mail.gun>'),
+        'addr': parse_list(u'"Федот" <стрелец@письмо.рф>, Марья <искусница@mail.gun>'),
         'repr': '[Федот <стрелец@письмо.рф>, Марья <искусница@mail.gun>]',
         'str': 'стрелец@письмо.рф, искусница@mail.gun',
         'unicode': u'Федот <стрелец@письмо.рф>, Марья <искусница@mail.gun>',

--- a/tests/addresslib/parser_address_list_test.py
+++ b/tests/addresslib/parser_address_list_test.py
@@ -35,7 +35,7 @@ def test_sanity():
 
 
 def test_simple_valid():
-    s = '''http://foo.com:8080; "Ev K." <ev@host.com>, "Alex K" alex@yahoo.net, "Tom, S" "tom+[a]"@s.com'''
+    s = '''http://foo.com:8080; "Ev K." <ev@host.com>, "Alex K" <alex@yahoo.net>, "Tom, S" <"tom+[a]"@s.com>'''
     addrs = parse_list(s)
 
     assert_equal(4, len(addrs))
@@ -97,7 +97,7 @@ def test_simple_valid():
     assert_equal(addrs[2].full_spec(), '=?utf-8?q?Gonzalo_Ba=C3=B1uelos?= <gonz@host.com>')
 
 
-    s = r'''"Escaped" "\e\s\c\a\p\e\d"@sld.com; http://userid:password@example.com:8080, "Dmitry" <my|'`!#_~%$&{}?^+-*@host.com>'''
+    s = r'''"Escaped" <"\e\s\c\a\p\e\d"@sld.com>; http://userid:password@example.com:8080, "Dmitry" <my|'`!#_~%$&{}?^+-*@host.com>'''
     addrs = parse_list(s)
 
     assert_equal(3, len(addrs))

--- a/tests/addresslib/parser_mailbox_test.py
+++ b/tests/addresslib/parser_mailbox_test.py
@@ -47,10 +47,7 @@ def test_mailbox():
     # sanity
     run_full_mailbox_test('Steve Jobs <steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
     run_full_mailbox_test('"Steve Jobs" <steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
-    run_mailbox_test('<steve@apple.com>', 'steve@apple.com')
 
-    run_full_mailbox_test('Steve Jobs steve@apple.com', EmailAddress('Steve Jobs', 'steve@apple.com'))
-    run_full_mailbox_test('"Steve Jobs" steve@apple.com', EmailAddress('Steve Jobs', 'steve@apple.com'))
     run_mailbox_test('steve@apple.com', 'steve@apple.com')
 
 
@@ -58,12 +55,10 @@ def test_name_addr():
     "Grammar: name-addr -> [ display-name ] angle-addr"
 
     # sanity
-    run_full_mailbox_test('Linus Torvalds linus@kernel.org', EmailAddress('Linus Torvalds','linus@kernel.org'))
     run_full_mailbox_test('Linus Torvalds <linus@kernel.org>', EmailAddress('Linus Torvalds','linus@kernel.org'))
     run_mailbox_test('Linus Torvalds', None)
     run_mailbox_test('Linus Torvalds <>', None)
     run_mailbox_test('linus@kernel.org', 'linus@kernel.org')
-    run_mailbox_test('<linus@kernel.org>', 'linus@kernel.org')
     try:
         run_mailbox_test(' ', None)
     except LexError:
@@ -88,26 +83,10 @@ def test_display_name():
     run_full_mailbox_test(' Bill Gates<bill@microsoft.com>', EmailAddress('Bill Gates', 'bill@microsoft.com'))
     run_full_mailbox_test(' Bill<bill@microsoft.com>', EmailAddress('Bill', 'bill@microsoft.com'))
 
-    # pass atom display-name lax
-    run_full_mailbox_test('ABCDEFGHIJKLMNOPQRSTUVWXYZ a@b', EmailAddress('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'a@b'))
-    run_full_mailbox_test('abcdefghijklmnopqrstuvwzyz a@b', EmailAddress('abcdefghijklmnopqrstuvwzyz', 'a@b'))
-    run_full_mailbox_test('0123456789 a@b', EmailAddress('0123456789', 'a@b'))
-    run_full_mailbox_test('!#$%&\'*+-/=?^_`{|}~ a@b', EmailAddress('!#$%&\'*+-/=?^_`{|}~', 'a@b'))
-    run_full_mailbox_test('Bill bill@microsoft.com', EmailAddress('Bill', 'bill@microsoft.com'))
-    run_full_mailbox_test('Bill Gates bill@microsoft.com', EmailAddress('Bill Gates', 'bill@microsoft.com'))
-    run_full_mailbox_test(' Bill  Gates bill@microsoft.com', EmailAddress('Bill Gates', 'bill@microsoft.com'))
-    run_full_mailbox_test(' Bill Gates bill@microsoft.com', EmailAddress('Bill Gates', 'bill@microsoft.com'))
-
-
     # fail atom display-name rfc
     run_full_mailbox_test('< <bill@microsoft.com>', None)
     run_full_mailbox_test('< bill <bill@microsoft.com>', None)
     run_full_mailbox_test(' < bill <bill@microsoft.com>', None)
-
-    # fail atom display-name lax
-    run_full_mailbox_test('< bill@microsoft.com', None)
-    run_full_mailbox_test('< bill bill@microsoft.com', None)
-    run_full_mailbox_test(' < bill @microsoft.com', None)
 
     # pass display-name quoted-string rfc
     run_full_mailbox_test('"{0}" <a@b>'.format(FULL_QTEXT),
@@ -139,34 +118,6 @@ def test_display_name():
         run_mailbox_test(u'"{0}" <a@b>'.format(cc), None)
         run_mailbox_test(u'{0} <a@b>'.format(cc), None)
 
-    # pass display-name quoted-string lax
-    run_full_mailbox_test('"{0}" a@b'.format(FULL_QTEXT),
-                          EmailAddress(FULL_QTEXT, 'a@b'))
-    run_full_mailbox_test('"{0}" a@b'.format(FULL_QUOTED_PAIR),
-                          EmailAddress(''.join(VALID_QUOTED_PAIR), 'a@b'))
-    run_full_mailbox_test('"a@b" a@b', EmailAddress('a@b', 'a@b'))
-    run_full_mailbox_test('"Bill" bill@microsoft.com',
-                          EmailAddress('Bill', 'bill@microsoft.com'))
-    run_full_mailbox_test('"Bill Gates" bill@microsoft.com',
-                          EmailAddress('Bill Gates', 'bill@microsoft.com'))
-    run_full_mailbox_test('" Bill Gates" bill@microsoft.com',
-                          EmailAddress(' Bill Gates', 'bill@microsoft.com'))
-    run_full_mailbox_test('"Bill Gates " bill@microsoft.com',
-                          EmailAddress('Bill Gates ', 'bill@microsoft.com'))
-    run_full_mailbox_test('" Bill Gates " bill@microsoft.com',
-                          EmailAddress(' Bill Gates ', 'bill@microsoft.com'))
-
-    # fail display-name quoted-string lax
-    run_mailbox_test('"{0} a@b"'.format(FULL_QUOTED_PAIR), None)
-    run_mailbox_test('"{0} a@b'.format(FULL_QTEXT), None)
-    run_mailbox_test('{0}" a@b'.format(FULL_QUOTED_PAIR), None)
-    run_mailbox_test('{0} a@b'.format(FULL_QUOTED_PAIR), None)
-    run_mailbox_test(u'{0} a@b'.format(''.join(CONTROL_CHARS)), None)
-    run_mailbox_test(u'"{0}" a@b'.format(''.join(CONTROL_CHARS)), None)
-    for cc in CONTROL_CHARS:
-        run_mailbox_test(u'{0} a@b'.format(cc), None)
-        run_mailbox_test(u'"{0}" a@b'.format(cc), None)
-
     # pass unicode display-name sanity
     run_full_mailbox_test(u'Bill <bill@microsoft.com>', EmailAddress(u'Bill', 'bill@microsoft.com'))
     run_full_mailbox_test(u'ϐill <bill@microsoft.com>', EmailAddress(u'ϐill', 'bill@microsoft.com'))
@@ -174,6 +125,9 @@ def test_display_name():
     run_full_mailbox_test(u'ϐΙλλ Γαθεσ <bill@microsoft.com>', EmailAddress(u'ϐΙλλ Γαθεσ', 'bill@microsoft.com'))
     run_full_mailbox_test(u'BΙλλ Γαθεσ <bill@microsoft.com>', EmailAddress(u'BΙλλ Γαθεσ', 'bill@microsoft.com'))
     run_full_mailbox_test(u'Bill Γαθεσ <bill@microsoft.com>', EmailAddress(u'Bill Γαθεσ', 'bill@microsoft.com'))
+
+    # period in display name
+    run_full_mailbox_test(u'Bill. Gates. <bill@microsoft.com>', EmailAddress(u'Bill. Gates.', 'bill@microsoft.com'))
 
 
 def test_unicode_display_name():
@@ -189,20 +143,6 @@ def test_unicode_display_name():
     run_full_mailbox_test(u'Foo Föö Foo <{0}>'.format(u'foo@example.com'),
         EmailAddress(u'Foo Föö Foo', 'foo@example.com'), '=?utf-8?b?Rm9vIEbDtsO2IEZvbw==?= <foo@example.com>')
     run_full_mailbox_test(u'Foo Föö Foo Föö <{0}>'.format(u'foo@example.com'),
-        EmailAddress(u'Foo Föö Foo Föö', 'foo@example.com'), '=?utf-8?b?Rm9vIEbDtsO2IEZvbyBGw7bDtg==?= <foo@example.com>')
-
-    # unicode, no quotes, display-name lax
-    run_full_mailbox_test(u'ö {0}'.format(u'foo@example.com'),
-        EmailAddress(u'ö', 'foo@example.com'), '=?utf-8?b?w7Y=?= <foo@example.com>')
-    run_full_mailbox_test(u'Föö {0}'.format(u'foo@example.com'),
-        EmailAddress(u'Föö', 'foo@example.com'), '=?utf-8?b?RsO2w7Y=?= <foo@example.com>')
-    run_full_mailbox_test(u'Foo ö {0}'.format(u'foo@example.com'),
-        EmailAddress(u'Foo ö', 'foo@example.com'), '=?utf-8?b?Rm9vIMO2?= <foo@example.com>')
-    run_full_mailbox_test(u'Foo Föö {0}'.format(u'foo@example.com'),
-        EmailAddress(u'Foo Föö', 'foo@example.com'), '=?utf-8?b?Rm9vIEbDtsO2?= <foo@example.com>')
-    run_full_mailbox_test(u'Foo Föö Foo {0}'.format(u'foo@example.com'),
-        EmailAddress(u'Foo Föö Foo', 'foo@example.com'), '=?utf-8?b?Rm9vIEbDtsO2IEZvbw==?= <foo@example.com>')
-    run_full_mailbox_test(u'Foo Föö Foo Föö {0}'.format(u'foo@example.com'),
         EmailAddress(u'Foo Föö Foo Föö', 'foo@example.com'), '=?utf-8?b?Rm9vIEbDtsO2IEZvbyBGw7bDtg==?= <foo@example.com>')
 
     # unicode, quotes, display-name rfc
@@ -229,33 +169,6 @@ def test_unicode_display_name():
         '=?utf-8?b?Rm9vIEbDtsO2IEZvbw==?= <foo@example.com>')
     run_full_mailbox_test(
         u'"Foo Föö Foo Föö" <foo@example.com>',
-        EmailAddress(u'Foo Föö Foo Föö', 'foo@example.com'),
-        '=?utf-8?b?Rm9vIEbDtsO2IEZvbyBGw7bDtg==?= <foo@example.com>')
-
-    # unicode, quotes, display-name lax
-    # Note that the quotes are removed from the parsed address
-    run_full_mailbox_test(
-        u'"ö" foo@example.com',
-        EmailAddress(u'ö', 'foo@example.com'),
-        '=?utf-8?b?w7Y=?= <foo@example.com>')
-    run_full_mailbox_test(
-        u'"Föö" foo@example.com',
-        EmailAddress(u'Föö', 'foo@example.com'),
-        '=?utf-8?b?RsO2w7Y=?= <foo@example.com>')
-    run_full_mailbox_test(
-        u'"Foo ö" foo@example.com',
-        EmailAddress(u'Foo ö', 'foo@example.com'),
-        '=?utf-8?b?Rm9vIMO2?= <foo@example.com>')
-    run_full_mailbox_test(
-        u'"Foo Föö" foo@example.com',
-        EmailAddress(u'Foo Föö', 'foo@example.com'),
-        '=?utf-8?b?Rm9vIEbDtsO2?= <foo@example.com>')
-    run_full_mailbox_test(
-        u'"Foo Föö Foo" foo@example.com',
-        EmailAddress(u'Foo Föö Foo', 'foo@example.com'),
-        '=?utf-8?b?Rm9vIEbDtsO2IEZvbw==?= <foo@example.com>')
-    run_full_mailbox_test(
-        u'"Foo Föö Foo Föö" foo@example.com',
         EmailAddress(u'Foo Föö Foo Föö', 'foo@example.com'),
         '=?utf-8?b?Rm9vIEbDtsO2IEZvbyBGw7bDtg==?= <foo@example.com>')
 
@@ -391,55 +304,55 @@ def test_unicode_special_chars():
         '=?utf-8?b?Zm9vIPCfkqkgYmFy?= <foo@example.com>')
 
     # unicode, language specific punctuation, just test with !
-    run_full_mailbox_test(u'fooǃ foo@example.com',
+    run_full_mailbox_test(u'fooǃ <foo@example.com>',
         EmailAddress(u'fooǃ', u'foo@example.com'),
         '=?utf-8?b?Zm9vx4M=?= <foo@example.com>')
-    run_full_mailbox_test(u'foo‼ foo@example.com',
+    run_full_mailbox_test(u'foo‼ <foo@example.com>',
         EmailAddress(u'foo‼', u'foo@example.com'),
         '=?utf-8?b?Zm9v4oC8?= <foo@example.com>')
-    run_full_mailbox_test(u'foo⁈ foo@example.com',
+    run_full_mailbox_test(u'foo⁈ <foo@example.com>',
         EmailAddress(u'foo⁈', u'foo@example.com'),
         '=?utf-8?b?Zm9v4oGI?= <foo@example.com>')
-    run_full_mailbox_test(u'foo⁉ foo@example.com',
+    run_full_mailbox_test(u'foo⁉ <foo@example.com>',
         EmailAddress(u'foo⁉', u'foo@example.com'),
         '=?utf-8?b?Zm9v4oGJ?= <foo@example.com>')
-    run_full_mailbox_test(u'foo❕ foo@example.com',
+    run_full_mailbox_test(u'foo❕ <foo@example.com>',
         EmailAddress(u'foo❕', u'foo@example.com'),
         '=?utf-8?b?Zm9v4p2V?= <foo@example.com>')
-    run_full_mailbox_test(u'foo❗ foo@example.com',
+    run_full_mailbox_test(u'foo❗ <foo@example.com>',
         EmailAddress(u'foo❗', u'foo@example.com'),
         '=?utf-8?b?Zm9v4p2X?= <foo@example.com>')
-    run_full_mailbox_test(u'foo❢ foo@example.com',
+    run_full_mailbox_test(u'foo❢ <foo@example.com>',
         EmailAddress(u'foo❢', u'foo@example.com'),
         '=?utf-8?b?Zm9v4p2i?= <foo@example.com>')
-    run_full_mailbox_test(u'foo❣ foo@example.com',
+    run_full_mailbox_test(u'foo❣ <foo@example.com>',
         EmailAddress(u'foo❣', u'foo@example.com'),
         '=?utf-8?b?Zm9v4p2j?= <foo@example.com>')
-    run_full_mailbox_test(u'fooꜝ foo@example.com',
+    run_full_mailbox_test(u'fooꜝ <foo@example.com>',
         EmailAddress(u'fooꜝ', u'foo@example.com'),
         '=?utf-8?b?Zm9v6pyd?= <foo@example.com>')
-    run_full_mailbox_test(u'fooꜞ foo@example.com',
+    run_full_mailbox_test(u'fooꜞ <foo@example.com>',
         EmailAddress(u'fooꜞ', u'foo@example.com'),
         '=?utf-8?b?Zm9v6pye?= <foo@example.com>')
-    run_full_mailbox_test(u'fooꜟ foo@example.com',
+    run_full_mailbox_test(u'fooꜟ <foo@example.com>',
         EmailAddress(u'fooꜟ', u'foo@example.com'),
         '=?utf-8?b?Zm9v6pyf?= <foo@example.com>')
-    run_full_mailbox_test(u'foo﹗ foo@example.com',
+    run_full_mailbox_test(u'foo﹗ <foo@example.com>',
         EmailAddress(u'foo﹗', u'foo@example.com'),
         '=?utf-8?b?Zm9v77mX?= <foo@example.com>')
-    run_full_mailbox_test(u'foo！ foo@example.com',
+    run_full_mailbox_test(u'foo！ <foo@example.com>',
         EmailAddress(u'foo！', u'foo@example.com'),
         '=?utf-8?b?Zm9v77yB?= <foo@example.com>')
-    run_full_mailbox_test(u'foo՜ foo@example.com',
+    run_full_mailbox_test(u'foo՜ <foo@example.com>',
         EmailAddress(u'foo՜', u'foo@example.com'),
         '=?utf-8?b?Zm9v1Zw=?= <foo@example.com>')
-    run_full_mailbox_test(u'foo߹ foo@example.com',
+    run_full_mailbox_test(u'foo߹ <foo@example.com>',
         EmailAddress(u'foo߹', u'foo@example.com'),
         '=?utf-8?b?Zm9v37k=?= <foo@example.com>')
-    run_full_mailbox_test(u'foo႟ foo@example.com',
+    run_full_mailbox_test(u'foo႟ <foo@example.com>',
         EmailAddress(u'foo႟', u'foo@example.com'),
         '=?utf-8?b?Zm9v4YKf?= <foo@example.com>')
-    run_full_mailbox_test(u'foo᥄ foo@example.com',
+    run_full_mailbox_test(u'foo᥄ <foo@example.com>',
         EmailAddress(u'foo᥄', u'foo@example.com'),
         '=?utf-8?b?Zm9v4aWE?= <foo@example.com>')
 
@@ -448,7 +361,6 @@ def test_angle_addr():
     "Grammar: angle-addr -> [ whitespace ] < addr-spec > [ whitespace ]"
 
     # pass angle-addr
-    run_mailbox_test('<steve@apple.com>', 'steve@apple.com')
     run_full_mailbox_test('Steve Jobs <steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
     run_full_mailbox_test('Steve Jobs < steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
     run_full_mailbox_test('Steve Jobs <steve@apple.com >', EmailAddress('Steve Jobs', 'steve@apple.com'))
@@ -528,7 +440,7 @@ def test_local_part():
     run_mailbox_test('" {0}"@b'.format(sample_qtext), '" {0}"@b'.format(sample_qtext))
     run_mailbox_test('"{0} "@b'.format(sample_qtext), '"{0} "@b'.format(sample_qtext))
     run_mailbox_test('" {0} "@b'.format(sample_qtext), '" {0} "@b'.format(sample_qtext))
-    run_full_mailbox_test('"{0}" "{0}"@b'.format(sample_qtext),
+    run_full_mailbox_test('"{0}" <"{0}"@b>'.format(sample_qtext),
         EmailAddress(sample_qtext, '"{0}"@b'.format(sample_qtext)))
 
     # fail qtext
@@ -543,7 +455,7 @@ def test_local_part():
     run_mailbox_test('" {0}"@b'.format(sample_qpair), '" {0}"@b'.format(sample_qpair))
     run_mailbox_test('"{0} "@b'.format(sample_qpair), '"{0} "@b'.format(sample_qpair))
     run_mailbox_test('" {0} "@b'.format(sample_qpair), '" {0} "@b'.format(sample_qpair))
-    run_full_mailbox_test('"{0}" "{0}"@b'.format(sample_qpair),
+    run_full_mailbox_test('"{0}" <"{0}"@b>'.format(sample_qpair),
         EmailAddress(sample_qpair_without_slashes, '"{0}"@b'.format(sample_qpair)))
 
     # fail quoted-pair


### PR DESCRIPTION
Allow period (aka "full stop") in the display name.

According to RFC 5322:
```
Note: The "period" (or "full stop") character (".") in obs-phrase
      is not a form that was allowed in earlier versions of this or any
      other specification.  Period (nor any other character from
      specials) was not allowed in phrase because it introduced a
      parsing difficulty distinguishing between phrases and portions of
      an addr-spec (see section 4.4).  It appears here because the
      period character is currently used in many messages in the
      display-name portion of addresses, especially for initials in
      names, and therefore must be interpreted properly.

obs-phrase = word *(word / "." / CFWS)
```

The period in the display name make parsing it much more difficult so there were a few things I had to drop support for to get this to work. Namely:
* The 2 invalid named address formats we allowed previously: `foo bar@baz.com` (missing brackets) and `<bar@baz.com>` (missing display name).
* Whitespace around the `@`. This is technically allowed like the period in the display name but I think it get used less frequently.