### PR TITLE
Add angle address without a display name

### DIFF
--- a/flanker/addresslib/parser.py
+++ b/flanker/addresslib/parser.py
@@ -40,6 +40,7 @@ def p_expression_url(p):
 
 def p_expression_mailbox(p):
     '''mailbox : addr_spec
+               | angle_addr
                | name_addr'''
     p[0] = p[1]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.7',
+      version='0.6.8',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -150,6 +150,20 @@ def test_display_name__to_full_spec():
 def test_views():
     for i, tc in enumerate([{
         # Pure ASCII
+        'addr': parse('foo@bar.com'),
+        'repr': 'foo@bar.com',
+        'str': 'foo@bar.com',
+        'unicode': u'foo@bar.com',
+        'full_spec': 'foo@bar.com',
+    }, {
+        # Pure ASCII
+        'addr': parse('<foo@bar.com>'),
+        'repr': 'foo@bar.com',
+        'str': 'foo@bar.com',
+        'unicode': u'foo@bar.com',
+        'full_spec': 'foo@bar.com',
+    }, {
+        # Pure ASCII
         'addr': parse('foo <foo@bar.com>'),
         'repr': 'foo <foo@bar.com>',
         'str': 'foo@bar.com',

--- a/tests/addresslib/parser_mailbox_test.py
+++ b/tests/addresslib/parser_mailbox_test.py
@@ -129,6 +129,9 @@ def test_display_name():
     # period in display name
     run_full_mailbox_test(u'Bill. Gates. <bill@microsoft.com>', EmailAddress(u'Bill. Gates.', 'bill@microsoft.com'))
 
+    # name addr without display name
+    run_full_mailbox_test(u'<bill@microsoft.com>', EmailAddress(None, 'bill@microsoft.com'))
+
 
 def test_unicode_display_name():
     # unicode, no quotes, display-name rfc


### PR DESCRIPTION
While removing an invalid grammer from the parser (`foo foo@bar.com`) I also removed the name address spec without a display name. This was a mistake since [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4) defines name address as `name-addr = [display-name] angle-addr`. This patch makes display name optional again.