### PR TITLE
Add support for comments in addresses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.10',
+      version='0.6.11',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/parser_mailbox_test.py
+++ b/tests/addresslib/parser_mailbox_test.py
@@ -504,6 +504,20 @@ def test_domain():
     run_mailbox_test('bill@microsoft.com"', None)
 
 
+def test_comments():
+    run_full_mailbox_test('(comment) Steve Jobs <steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('Steve Jobs (comment) <steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('Steve Jobs <(comment) steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('Steve Jobs <steve@apple.com (comment)>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('Steve Jobs <steve@apple.com> (comment)', EmailAddress('Steve Jobs', 'steve@apple.com'))
+
+    run_full_mailbox_test('(comment)"Steve Jobs"<steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('"Steve Jobs"(comment)<steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('"Steve Jobs"<(comment)steve@apple.com>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('"Steve Jobs"<steve@apple.com(comment)>', EmailAddress('Steve Jobs', 'steve@apple.com'))
+    run_full_mailbox_test('"Steve Jobs"<steve@apple.com>(comment)', EmailAddress('Steve Jobs', 'steve@apple.com'))
+
+
 def test_full_spec_symmetry_bug():
     """
     There was a bug that if an address has a display name that is equal or

--- a/tests/fixtures/mailbox_valid.txt
+++ b/tests/fixtures/mailbox_valid.txt
@@ -198,6 +198,10 @@ cdburgess+!#$%&'*-/=?+_{}|~test@mail.com
 test@test.com
 test@xn--example.com
 test@example.com
+(this is a comment) test@example.com
+(this is a comment)test@example.com
+test@example.com(this is a comment)
+test@example.com (this is a comment)
 
 #
 # Sample valid international email addresses from https://en.wikipedia.org/wiki/International_email


### PR DESCRIPTION
This PR adds comments support to the most commonly used placed in email addresses. It does not attempt to support comments in every place they are technically allowed (in the middle of dot-atoms, middle of the display name, next to the `@` sign, etc.) since that would could problems for the parser. Still, this should cover the vast majority of addresses with comments we see.