### PR TITLE
Optionally fallback to parsing last word of addresses

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -244,7 +244,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
         parsed, unparsed = AddressList(), [address_list]
     elif isinstance(address_list, basestring):
         if not strict:
-            log.warning('relaxed parsing is not available for discrete lists, ignoring')
+            log.info('relaxed parsing is not available for discrete lists, ignoring')
         retval, metrics = parse_discrete_list(address_list, metrics=True)
         mtimes['parsing'] += metrics['parsing']
         if retval:

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -115,6 +115,8 @@ def parse(address, addr_spec_only=False, metrics=False, fallback_last_word=False
 
             retval = _lift_parser_result(parser.parse(addr_spec, lexer=lexer.clone()))
             retval._display_name = display_name
+            if isinstance(retval._display_name, str):
+                retval._display_name = retval._display_name.decode('utf-8')
 
             mtimes['parsing'] += time() - bstart
 

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -113,7 +113,7 @@ def parse(address, addr_spec_only=False, metrics=False, fallback_last_word=False
             addr_spec = addr_parts[-1]
             display_name = ' '.join(addr_parts[0:-1])
 
-            retval = _lift_parser_result(addr_spec_parser.parse(addr_spec, lexer=lexer.clone()))
+            retval = _lift_parser_result(parser.parse(addr_spec, lexer=lexer.clone()))
             retval._display_name = display_name
 
             mtimes['parsing'] += time() - bstart
@@ -179,7 +179,7 @@ def parse_discrete_list(address_list, metrics=False):
     return retval, mtimes
 
 @metrics_wrapper()
-def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
+def parse_list(address_list, strict=False, as_tuple=False, metrics=False, fallback_last_word=False):
     """
     Given an string or list of email addresses and/or urls seperated by a
     delimiter (comma (,) or semi-colon (;)), returns an AddressList object
@@ -219,7 +219,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
         parsed, unparsed = AddressList(), []
         for address in address_list:
             if isinstance(address, basestring):
-                retval, metrics = parse(address, metrics=True)
+                retval, metrics = parse(address, metrics=True, fallback_last_word=fallback_last_word)
                 mtimes['parsing'] += metrics['parsing']
                 if retval:
                     parsed.append(retval)
@@ -236,6 +236,8 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
         log.warning('address list exceeds maximum length of %s', MAX_ADDRESS_LIST_LENGTH)
         parsed, unparsed = AddressList(), [address_list]
     elif isinstance(address_list, basestring):
+        if fallback_last_word:
+            log.warning('fallback parsing is not available for discrete lists, ignoring')
         retval, metrics = parse_discrete_list(address_list, metrics=True)
         mtimes['parsing'] += metrics['parsing']
         if retval:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.11',
+      version='0.6.12',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -258,3 +258,10 @@ def test_requires_non_ascii():
 def test_contains_domain_literal():
     eq_(EmailAddress(None, 'foo@bar.com').contains_domain_literal(), False)
     eq_(EmailAddress(None, 'foo@[1.2.3.4]').contains_domain_literal(), True)
+
+
+def test_parse_fallback_last_word():
+    eq_('foo <foo@bar.com>',             parse('foo <foo@bar.com>', fallback_last_word=True).full_spec())
+    eq_('foo <foo@bar.com>',             parse('foo foo@bar.com', fallback_last_word=True).full_spec())
+    eq_('"foo (comment)" <foo@bar.com>', parse('foo (comment) foo@bar.com', fallback_last_word=True).full_spec())
+    eq_('"not@valid" <foo@bar.com>',     parse('not@valid foo@bar.com', fallback_last_word=True).full_spec())

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -261,15 +261,16 @@ def test_contains_domain_literal():
 
 
 def test_parse_fallback_last_word():
-    eq_('foo <foo@bar.com>',             parse('foo <foo@bar.com>', fallback_last_word=True).full_spec())
-    eq_('foo <foo@bar.com>',             parse('foo foo@bar.com', fallback_last_word=True).full_spec())
-    eq_('foo <foo@bar.com>',             parse('foo (comment) <foo@bar.com>', fallback_last_word=True).full_spec())
-    eq_('"foo (comment)" <foo@bar.com>', parse('foo (comment) foo@bar.com', fallback_last_word=True).full_spec())
-    eq_('"not@valid" <foo@bar.com>',     parse('not@valid <foo@bar.com>', fallback_last_word=True).full_spec())
-    eq_('"not@valid" <foo@bar.com>',     parse('not@valid foo@bar.com', fallback_last_word=True).full_spec())
+    eq_(u'foo <foo@bar.com>',             parse('foo <foo@bar.com>', fallback_last_word=True).to_unicode())
+    eq_(u'foo <foo@bar.com>',             parse('foo foo@bar.com', fallback_last_word=True).to_unicode())
+    eq_(u'foo <foo@bar.com>',             parse('foo (comment) <foo@bar.com>', fallback_last_word=True).to_unicode())
+    eq_(u'"foo (comment)" <foo@bar.com>', parse('foo (comment) foo@bar.com', fallback_last_word=True).to_unicode())
+    eq_(u'"not@valid" <foo@bar.com>',     parse('not@valid <foo@bar.com>', fallback_last_word=True).to_unicode())
+    eq_(u'"not@valid" <foo@bar.com>',     parse('not@valid foo@bar.com', fallback_last_word=True).to_unicode())
+    eq_(u'Маруся <мария@example.com>',    parse('Маруся мария@example.com', fallback_last_word=True).to_unicode())
 
 
 def test_parse_list_fallback_last_word():
     addr_list = ['foo <foo@bar.com>', 'foo foo@bar.com', 'not@valid <foo@bar.com>']
     expected = ['foo <foo@bar.com>', 'foo <foo@bar.com>', '"not@valid" <foo@bar.com>']
-    eq_(expected, [addr.full_spec() for addr in parse_list(addr_list, fallback_last_word=True)])
+    eq_(expected, [addr.to_unicode() for addr in parse_list(addr_list, fallback_last_word=True)])

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -260,17 +260,17 @@ def test_contains_domain_literal():
     eq_(EmailAddress(None, 'foo@[1.2.3.4]').contains_domain_literal(), True)
 
 
-def test_parse_fallback_last_word():
-    eq_(u'foo <foo@bar.com>',             parse('foo <foo@bar.com>', fallback_last_word=True).to_unicode())
-    eq_(u'foo <foo@bar.com>',             parse('foo foo@bar.com', fallback_last_word=True).to_unicode())
-    eq_(u'foo <foo@bar.com>',             parse('foo (comment) <foo@bar.com>', fallback_last_word=True).to_unicode())
-    eq_(u'"foo (comment)" <foo@bar.com>', parse('foo (comment) foo@bar.com', fallback_last_word=True).to_unicode())
-    eq_(u'"not@valid" <foo@bar.com>',     parse('not@valid <foo@bar.com>', fallback_last_word=True).to_unicode())
-    eq_(u'"not@valid" <foo@bar.com>',     parse('not@valid foo@bar.com', fallback_last_word=True).to_unicode())
-    eq_(u'Маруся <мария@example.com>',    parse('Маруся мария@example.com', fallback_last_word=True).to_unicode())
+def test_parse_relaxed():
+    eq_(u'foo <foo@bar.com>',             parse('foo <foo@bar.com>').to_unicode())
+    eq_(u'foo <foo@bar.com>',             parse('foo foo@bar.com').to_unicode())
+    eq_(u'foo <foo@bar.com>',             parse('foo (comment) <foo@bar.com>').to_unicode())
+    eq_(u'"foo (comment)" <foo@bar.com>', parse('foo (comment) foo@bar.com').to_unicode())
+    eq_(u'"not@valid" <foo@bar.com>',     parse('not@valid <foo@bar.com>').to_unicode())
+    eq_(u'"not@valid" <foo@bar.com>',     parse('not@valid foo@bar.com').to_unicode())
+    eq_(u'Маруся <мария@example.com>',    parse('Маруся мария@example.com').to_unicode())
 
 
-def test_parse_list_fallback_last_word():
+def test_parse_list_relaxed():
     addr_list = ['foo <foo@bar.com>', 'foo foo@bar.com', 'not@valid <foo@bar.com>']
     expected = ['foo <foo@bar.com>', 'foo <foo@bar.com>', '"not@valid" <foo@bar.com>']
-    eq_(expected, [addr.to_unicode() for addr in parse_list(addr_list, fallback_last_word=True)])
+    eq_(expected, [addr.to_unicode() for addr in parse_list(addr_list)])

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -263,5 +263,13 @@ def test_contains_domain_literal():
 def test_parse_fallback_last_word():
     eq_('foo <foo@bar.com>',             parse('foo <foo@bar.com>', fallback_last_word=True).full_spec())
     eq_('foo <foo@bar.com>',             parse('foo foo@bar.com', fallback_last_word=True).full_spec())
+    eq_('foo <foo@bar.com>',             parse('foo (comment) <foo@bar.com>', fallback_last_word=True).full_spec())
     eq_('"foo (comment)" <foo@bar.com>', parse('foo (comment) foo@bar.com', fallback_last_word=True).full_spec())
+    eq_('"not@valid" <foo@bar.com>',     parse('not@valid <foo@bar.com>', fallback_last_word=True).full_spec())
     eq_('"not@valid" <foo@bar.com>',     parse('not@valid foo@bar.com', fallback_last_word=True).full_spec())
+
+
+def test_parse_list_fallback_last_word():
+    addr_list = ['foo <foo@bar.com>', 'foo foo@bar.com', 'not@valid <foo@bar.com>']
+    expected = ['foo <foo@bar.com>', 'foo <foo@bar.com>', '"not@valid" <foo@bar.com>']
+    eq_(expected, [addr.full_spec() for addr in parse_list(addr_list, fallback_last_word=True)])

--- a/tests/addresslib/external_dataset_test.py
+++ b/tests/addresslib/external_dataset_test.py
@@ -22,7 +22,7 @@ def test_mailbox_valid_set():
         if match:
             continue
 
-        mbox = address.parse(line)
+        mbox = address.parse(line, strict=True)
         assert_not_equal(mbox, None)
 
 def test_mailbox_invalid_set():
@@ -37,7 +37,7 @@ def test_mailbox_invalid_set():
         if match:
             continue
 
-        mbox = address.parse(line)
+        mbox = address.parse(line, strict=True)
         assert_equal(mbox, None)
 
 def test_url_valid_set():
@@ -52,7 +52,7 @@ def test_url_valid_set():
         if match:
             continue
 
-        mbox = address.parse(line)
+        mbox = address.parse(line, strict=True)
         assert_not_equal(mbox, None)
 
 def test_url_invalid_set():
@@ -67,5 +67,5 @@ def test_url_invalid_set():
         if match:
             continue
 
-        mbox = address.parse(line)
+        mbox = address.parse(line, strict=True)
         assert_equal(mbox, None)

--- a/tests/addresslib/parser_address_list_test.py
+++ b/tests/addresslib/parser_address_list_test.py
@@ -16,7 +16,7 @@ def powerset(iterable):
 
 @nottest
 def run_test(string, expected_mlist):
-    mlist = parse_list(string)
+    mlist = parse_list(string, strict=True)
     assert_equal(mlist, expected_mlist)
 
 
@@ -36,7 +36,7 @@ def test_sanity():
 
 def test_simple_valid():
     s = '''http://foo.com:8080; "Ev K." <ev@host.com>, "Alex K" <alex@yahoo.net>, "Tom, S" <"tom+[a]"@s.com>'''
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(4, len(addrs))
 
@@ -61,7 +61,7 @@ def test_simple_valid():
 
 
     s = '''"Allan G\'o"  <allan@example.com>, "Os Wi" <oswi@example.com>'''
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(2, len(addrs))
 
@@ -77,7 +77,7 @@ def test_simple_valid():
 
 
     s = u'''I am also A <a@HOST.com>, Zeka <EV@host.coM> ;Gonzalo Bañuelos<gonz@host.com>'''
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(3, len(addrs))
 
@@ -98,7 +98,7 @@ def test_simple_valid():
 
 
     s = r'''"Escaped" <"\e\s\c\a\p\e\d"@sld.com>; http://userid:password@example.com:8080, "Dmitry" <my|'`!#_~%$&{}?^+-*@host.com>'''
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(3, len(addrs))
 
@@ -118,7 +118,7 @@ def test_simple_valid():
 
 
     s = "http://foo.com/blah_blah_(wikipedia)"
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(1, len(addrs))
 
@@ -128,7 +128,7 @@ def test_simple_valid():
 
 
     s = "Sasha Klizhentas <klizhentas@gmail.com>"
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(1, len(addrs))
 
@@ -139,7 +139,7 @@ def test_simple_valid():
 
 
     s = "admin@mailgunhq.com,lift@example.com"
-    addrs = parse_list(s)
+    addrs = parse_list(s, strict=True)
 
     assert_equal(2, len(addrs))
 
@@ -156,13 +156,13 @@ def test_simple_valid():
 
 def test_simple_invalid():
     s = '''httd://foo.com:8080\r\n; "Ev K." <ev@ host.com>\n "Alex K" alex@ , "Tom, S" "tom+["  a]"@s.com'''
-    assert_equal(AddressList(), parse_list(s))
+    assert_equal(AddressList(), parse_list(s, strict=True))
 
     s = ""
-    assert_equal(AddressList(), parse_list(s))
+    assert_equal(AddressList(), parse_list(s, strict=True))
 
     s = "crap"
-    assert_equal(AddressList(), parse_list(s))
+    assert_equal(AddressList(), parse_list(s, strict=True))
 
 
 def test_endpoints():

--- a/tests/addresslib/parser_mailbox_test.py
+++ b/tests/addresslib/parser_mailbox_test.py
@@ -22,19 +22,19 @@ def chunks(l, n):
 
 @nottest
 def run_full_mailbox_test(string, expected, full_spec=None):
-    mbox = address.parse(string)
+    mbox = address.parse(string, strict=True)
     if mbox:
         assert_equal(expected.display_name, mbox.display_name)
         assert_equal(expected.address, mbox.address)
         if full_spec:
             assert_equal(full_spec, mbox.full_spec())
-        assert_equal(mbox, address.parse(mbox.to_unicode())) # check symmetry
+        assert_equal(mbox, address.parse(mbox.to_unicode(), strict=True)) # check symmetry
         return
     assert_equal(expected, mbox)
 
 @nottest
 def run_mailbox_test(string, expected_string):
-    mbox = address.parse(string)
+    mbox = address.parse(string, strict=True)
     if mbox:
         assert_equal(expected_string, mbox.address)
         return


### PR DESCRIPTION
This PR adds a fallback method of parsing addresses which supports a variety of address formats we used to accept. If the address can't be parsed normally and `fallback_last_word` evaluates to true the parser will split the address on spaces and assume the last word is the address. The remaining parts are assumed to be the display name. This works for addresses with missing angle brackets surrounding address spec (`foo foo@bar.com`) and special characters in the display name (`not@valid <foo@bar.com>`) as well as many other cases. The intended formatting of the display name may not be preserved 100% in these cases but since the address isn't RFC compliant anyway there's really no way around it. 