### PR TITLE
Normalize unicode representation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.12',
+      version='0.6.13',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -1,10 +1,9 @@
 # coding:utf-8
+from nose.tools import assert_raises, eq_, ok_
 
-from .. import *
-from nose.tools import assert_equal, assert_not_equal, assert_raises
-
+from flanker.addresslib.address import (Address, AddressList, EmailAddress,
+                                        UrlAddress)
 from flanker.addresslib.address import parse, parse_list
-from flanker.addresslib.address import Address, AddressList, EmailAddress, UrlAddress
 
 
 def test_addr_properties():
@@ -147,80 +146,396 @@ def test_display_name__to_full_spec():
         EmailAddress(u'Привет Медвед', 'foo@bar.com').full_spec())
 
 
-def test_views():
+def test_address_convertible_2_ascii():
     for i, tc in enumerate([{
-        # Pure ASCII
-        'addr': parse('foo@bar.com'),
-        'repr': 'foo@bar.com',
-        'str': 'foo@bar.com',
-        'unicode': u'foo@bar.com',
-        'full_spec': 'foo@bar.com',
+        'desc': 'display_name=empty, domain=ascii',
+        'addr': 'Foo@Bar.com',
+
+        'display_name':      '',
+        'ace_display_name':  '',
+        'address':           'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':              'Foo@bar.com',
+        'str':               'Foo@bar.com',
+        'unicode':          u'Foo@bar.com',
+        'full_spec':         'Foo@bar.com',
     }, {
-        # Pure ASCII
-        'addr': parse('<foo@bar.com>'),
-        'repr': 'foo@bar.com',
-        'str': 'foo@bar.com',
-        'unicode': u'foo@bar.com',
-        'full_spec': 'foo@bar.com',
+        'desc': 'display_name=ascii, domain=ascii',
+        'addr': 'Blah <Foo@Bar.com>',
+
+        'display_name':      'Blah',
+        'ace_display_name':  'Blah',
+        'address':           'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':              'Blah <Foo@bar.com>',
+        'str':               'Foo@bar.com',
+        'unicode':          u'Blah <Foo@bar.com>',
+        'full_spec':         'Blah <Foo@bar.com>',
     }, {
-        # Pure ASCII
-        'addr': parse('foo <foo@bar.com>'),
-        'repr': 'foo <foo@bar.com>',
-        'str': 'foo@bar.com',
-        'unicode': u'foo <foo@bar.com>',
-        'full_spec': 'foo <foo@bar.com>',
+        'desc': 'display_name=utf8, domain=ascii',
+        'addr': u'Федот <Foo@Bar.com>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':           'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':             u'Федот <Foo@bar.com>'.encode('utf-8'),
+        'str':               'Foo@bar.com',
+        'unicode':          u'Федот <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@bar.com>',
     }, {
-        # UTF-8
-        'addr': parse(u'Федот <стрелец@письмо.рф>'),
-        'repr': 'Федот <стрелец@письмо.рф>',
-        'str': 'стрелец@письмо.рф',
-        'unicode': u'Федот <стрелец@письмо.рф>',
-        'full_spec': ValueError(),
+        'desc': 'display_name=encoded-utf8, domain=ascii',
+        'addr': '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@Bar.com>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':           'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':             u'Федот <Foo@bar.com>'.encode('utf-8'),
+        'str':               'Foo@bar.com',
+        'unicode':          u'Федот <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@bar.com>',
     }, {
-        # UTF-8
-        'addr': parse(u'"Федот" <стрелец@письмо.рф>'),
-        'repr': 'Федот <стрелец@письмо.рф>',
-        'str': 'стрелец@письмо.рф',
-        'unicode': u'Федот <стрелец@письмо.рф>',
-        'full_spec': ValueError(),
+        'desc': 'display_name=bad-encoding, domain=ascii',
+        'addr': '=?blah0KTQtdC00L7Rgg==?= <Foo@Bar.com>',
+
+        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'address':           'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>'.encode('utf-8'),
+        'str':               'Foo@bar.com',
+        'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>',
+        'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>',
     }, {
-        # ASCII with utf-8 encoded display name
-        'addr': parse('=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>'),
-        'repr': '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>',
-        'str': 'foo@bar.com',
-        'unicode': '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>',
-        'full_spec': '=?utf-8?b?0LDQtNC20LDQuQ==?= <foo@bar.com>',
+        'desc': 'display_name=empty, domain=utf8',
+        'addr': u'Foo@Почта.рф',
+
+        'display_name':      '',
+        'ace_display_name':  '',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Foo@почта.рф'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Foo@почта.рф',
+        'full_spec':         'Foo@xn--80a1acny.xn--p1ai',
     }, {
-        # IDNA domain
-        'addr': parse('foo <foo@экзампл.рус>'),
-        'repr': 'foo <foo@экзампл.рус>',
-        'str': 'foo@экзампл.рус',
-        'unicode': u'foo <foo@экзампл.рус>',
-        'full_spec': 'foo <foo@xn--80aniges7g.xn--p1acf>',
+        'desc': 'display_name=ascii, domain=utf8',
+        'addr': u'Blah <Foo@Почта.рф>',
+
+        'display_name':      'Blah',
+        'ace_display_name':  'Blah',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Blah <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Blah <Foo@почта.рф>',
+        'full_spec':         'Blah <Foo@xn--80a1acny.xn--p1ai>',
     }, {
-        # UTF-8 local part
-        'addr': parse(u'foo <аджай@bar.com>'),
-        'repr': 'foo <аджай@bar.com>',
-        'str': 'аджай@bar.com',
-        'unicode': u'foo <аджай@bar.com>',
-        'full_spec': ValueError(),
+        'desc': 'display_name=utf8, domain=utf8',
+        'addr': u'Федот <Foo@Почта.рф>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Foo@почта.рф>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
-        # UTF-8 address list
-        'addr': parse_list(u'"Федот" <стрелец@письмо.рф>, Марья <искусница@mail.gun>'),
-        'repr': '[Федот <стрелец@письмо.рф>, Марья <искусница@mail.gun>]',
-        'str': 'стрелец@письмо.рф, искусница@mail.gun',
-        'unicode': u'Федот <стрелец@письмо.рф>, Марья <искусница@mail.gun>',
-        'full_spec': ValueError(),
+        'desc': 'display_name=encoded-utf8, domain=utf8',
+        'addr': u'=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@Почта.рф>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Foo@почта.рф>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+    }, {
+        'desc': 'display_name=bad-encoding, domain=utf8',
+        'addr': u'=?blah0KTQtdC00L7Rgg==?= <Foo@Почта.рф>',
+
+        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
+        'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+    }, {
+        'desc': 'display_name=empty, domain=punycode',
+        'addr': 'Foo@xn--80a1acny.xn--p1ai',
+
+        'display_name':      '',
+        'ace_display_name':  '',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Foo@почта.рф'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Foo@почта.рф',
+        'full_spec':         'Foo@xn--80a1acny.xn--p1ai',
+    }, {
+        'desc': 'display_name=ascii, domain=punycode',
+        'addr': 'Blah <Foo@xn--80a1acny.xn--p1ai>',
+
+        'display_name':      'Blah',
+        'ace_display_name':  'Blah',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Blah <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Blah <Foo@почта.рф>',
+        'full_spec':         'Blah <Foo@xn--80a1acny.xn--p1ai>',
+    }, {
+        'desc': 'display_name=utf8, domain=punycode',
+        'addr': 'Федот <Foo@xn--80a1acny.xn--p1ai>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Foo@почта.рф>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+    }, {
+        'desc': 'display_name=encoded-utf8, domain=punycode',
+        'addr': '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Foo@почта.рф>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+    }, {
+        'desc': 'display_name=bad-encoding, domain=punycode',
+        'addr': '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+
+        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@почта.рф',
+        'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
+        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>'.encode('utf-8'),
+        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
+        'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+    }]):
+        print('Test case #%d: %s' % (i, tc['desc']))
+        # When
+        addr = parse(tc['addr'])
+        # Then
+        assert isinstance(addr, EmailAddress)
+        eq_(False, addr.requires_non_ascii())
+        eq_(tc['display_name'], addr.display_name)
+        eq_(tc['ace_display_name'], addr.ace_display_name)
+        eq_(tc['address'], addr.address)
+        eq_(tc['ace_address'], addr.ace_address)
+        eq_(tc['repr'], repr(addr))
+        eq_(tc['str'], str(addr))
+        eq_(tc['unicode'], unicode(addr))
+        eq_(tc['unicode'], addr.to_unicode())
+        eq_(tc['full_spec'], addr.full_spec())
+
+
+def test_address_requires_utf8():
+    for i, tc in enumerate([{
+        'desc': 'display_name=empty, domain=ascii',
+        'addr': u'Фью@Bar.com',
+
+        'display_name':      '',
+        'ace_display_name':  '',
+        'address':          u'Фью@bar.com',
+        'repr':             u'Фью@bar.com'.encode('utf-8'),
+        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'unicode':          u'Фью@bar.com',
+    }, {
+        'desc': 'display_name=ascii, domain=ascii',
+        'addr': u'Blah <Фью@Bar.com>',
+
+        'display_name':      'Blah',
+        'ace_display_name':  'Blah',
+        'address':          u'Фью@bar.com',
+        'repr':             u'Blah <Фью@bar.com>'.encode('utf-8'),
+        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'unicode':          u'Blah <Фью@bar.com>',
+    }, {
+        'desc': 'display_name=utf8, domain=ascii',
+        'addr': u'Федот <Фью@Bar.com>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@bar.com',
+        'repr':             u'Федот <Фью@bar.com>'.encode('utf-8'),
+        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'unicode':          u'Федот <Фью@bar.com>',
+    }, {
+        'desc': 'display_name=encoded-utf8, domain=ascii',
+        'addr': u'=?utf-8?b?0KTQtdC00L7Rgg==?= <Фью@Bar.com>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@bar.com',
+        'repr':             u'Федот <Фью@bar.com>'.encode('utf-8'),
+        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'unicode':          u'Федот <Фью@bar.com>',
+    }, {
+        'desc': 'display_name=bad-encoding, domain=ascii',
+        'addr': u'=?blah0KTQtdC00L7Rgg==?= <Фью@Bar.com>',
+
+        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@bar.com',
+        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@bar.com>'.encode('utf-8'),
+        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Фью@bar.com>',
+    }, {
+        'desc': 'display_name=empty, domain=utf8',
+        'addr': u'Фью@Почта.рф',
+
+        'display_name':      '',
+        'ace_display_name':  '',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'Фью@почта.рф'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'Фью@почта.рф',
+    }, {
+        'desc': 'display_name=ascii, domain=utf8',
+        'addr': u'Blah <Фью@Почта.рф>',
+
+        'display_name':      'Blah',
+        'ace_display_name':  'Blah',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'Blah <Фью@почта.рф>'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'Blah <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=utf8, domain=utf8',
+        'addr': u'Федот <Фью@Почта.рф>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=encoded-utf8, domain=utf8',
+        'addr': u'=?utf-8?b?0KTQtdC00L7Rgg==?= <Фью@Почта.рф>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=bad-encoding, domain=utf8',
+        'addr': u'=?blah0KTQtdC00L7Rgg==?= <Фью@Почта.рф>',
+
+        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=empty, domain=punycode',
+        'addr': u'Фью@xn--80a1acny.xn--p1ai',
+
+        'display_name':      '',
+        'ace_display_name':  '',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'Фью@почта.рф'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'Фью@почта.рф',
+    }, {
+        'desc': 'display_name=ascii, domain=punycode',
+        'addr': u'Blah <Фью@xn--80a1acny.xn--p1ai>',
+
+        'display_name':     'Blah',
+        'ace_display_name': 'Blah',
+        'address':         u'Фью@почта.рф',
+        'repr':            u'Blah <Фью@почта.рф>'.encode('utf-8'),
+        'str':             u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':         u'Blah <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=utf8, domain=punycode',
+        'addr': u'Федот <Фью@xn--80a1acny.xn--p1ai>',
+
+        'display_name':    u'Федот',
+        'ace_display_name': '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':         u'Фью@почта.рф',
+        'repr':            u'Федот <Фью@почта.рф>'.encode('utf-8'),
+        'str':             u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':         u'Федот <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=encoded-utf8, domain=punycode',
+        'addr': u'=?utf-8?b?0KTQtdC00L7Rgg==?= <Фью@xn--80a1acny.xn--p1ai>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'Федот <Фью@почта.рф>',
+    }, {
+        'desc': 'display_name=bad-encoding, domain=punycode',
+        'addr': u'=?blah0KTQtdC00L7Rgg==?= <Фью@xn--80a1acny.xn--p1ai>',
+
+        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'address':          u'Фью@почта.рф',
+        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>'.encode('utf-8'),
+        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>',
+    }]):
+        print('Test case #%d: %s' % (i, tc['desc']))
+        # When
+        addr = parse(tc['addr'])
+        # Then
+        assert isinstance(addr, EmailAddress)
+        eq_(True, addr.requires_non_ascii())
+        eq_(tc['display_name'], addr.display_name)
+        eq_(tc['ace_display_name'], addr.ace_display_name)
+        eq_(tc['address'], addr.address)
+        with assert_raises(ValueError):
+            _ = addr.ace_address
+        eq_(tc['repr'], repr(addr))
+        eq_(tc['str'], str(addr))
+        eq_(tc['unicode'], unicode(addr))
+        eq_(tc['unicode'], addr.to_unicode())
+        with assert_raises(ValueError):
+            addr.full_spec()
+
+
+def test_address_properties_req_utf8():
+    for i, tc in enumerate([{
+        'desc': 'utf8',
+        'addr_list': u'"Федот" <стрелец@письмо.рф>, Марья <искусница@mail.gun>',
+
+        'repr':       '[Федот <стрелец@письмо.рф>, Марья <искусница@mail.gun>]',
+        'str':        'стрелец@письмо.рф, искусница@mail.gun',
+        'unicode':   u'Федот <стрелец@письмо.рф>, Марья <искусница@mail.gun>',
+        'full_spec':  ValueError(),
     }]):
         print('Test case #%d' % i)
-        eq_(tc['repr'], repr(tc['addr']))
-        eq_(tc['str'], str(tc['addr']))
-        eq_(tc['unicode'], unicode(tc['addr']))
-        eq_(tc['unicode'], tc['addr'].to_unicode())
+        addr_list = parse_list(tc['addr_list'])
+        eq_(tc['repr'], repr(addr_list))
+        eq_(tc['str'], str(addr_list))
+        eq_(tc['unicode'], unicode(addr_list))
+        eq_(tc['unicode'], addr_list.to_unicode())
         if isinstance(tc['full_spec'], Exception):
-            assert_raises(type(tc['full_spec']), tc['addr'].full_spec)
+            assert_raises(type(tc['full_spec']), addr_list.full_spec)
         else:
-            eq_(tc['full_spec'], tc['addr'].full_spec())
+            eq_(tc['full_spec'], addr_list.full_spec())
 
 
 def test_address_full_spec_smart_quote_display_name():
@@ -244,15 +559,6 @@ def test_contains_non_ascii():
     eq_(EmailAddress(None, 'foo@экзампл.рус').contains_non_ascii(), True)
     eq_(EmailAddress(None, 'аджай@bar.com').contains_non_ascii(), True)
     eq_(EmailAddress(None, 'аджай@экзампл.рус').contains_non_ascii(), True)
-
-
-def test_requires_non_ascii():
-    eq_(EmailAddress(None, 'foo@bar.com').requires_non_ascii(), False)
-    eq_(EmailAddress(None, 'foo@экзампл.рус').requires_non_ascii(), False)
-    eq_(EmailAddress(None, 'foo@xn--0.pt').requires_non_ascii(), False)
-    eq_(EmailAddress(None, 'foo@日本語。ＪＰ').requires_non_ascii(), True)
-    eq_(EmailAddress(None, 'аджай@bar.com').requires_non_ascii(), True)
-    eq_(EmailAddress(None, 'аджай@экзампл.рус').requires_non_ascii(), True)
 
 
 def test_contains_domain_literal():

--- a/tests/fixtures/mailbox_invalid.txt
+++ b/tests/fixtures/mailbox_invalid.txt
@@ -98,6 +98,7 @@ a@bar.com.
 -@..com
 -@a..com
 test@...........com
+test@xn--example.com
 # first.last@[IPv6::]                                                                   # domain literal
 # first.last@[IPv6::::]                                                                 # domain literal
 # first.last@[IPv6::b4]                                                                 # domain literal

--- a/tests/fixtures/mailbox_valid.txt
+++ b/tests/fixtures/mailbox_valid.txt
@@ -196,7 +196,6 @@ cdburgess+!#$%&'*-/=?+_{}|~test@mail.com
 # first.last@[IPv6:0123:4567:89ab:CDEF::11.22.33.44]                                    # domain literal
 # first.last@[IPv6:a1::b2:11.22.33.44]                                                  # domain literal
 test@test.com
-test@xn--example.com
 test@example.com
 (this is a comment) test@example.com
 (this is a comment)test@example.com


### PR DESCRIPTION
### Problem
In the world where only a few ESP properly support UTF-8 addresses we need a convenient way to construct pure-ASCII address representation **without display name** where possible.
### Solution
`ace_address` property was introduced that returns pure-ASCII address representation or raises `ValueError` if that is impossible.
### Misc
* `display_name` property is now a human readable unicode string even if it was [rfc2047](https://www.ietf.org/rfc/rfc2047.txt) encoded in the original parsed address;
* `ace_display_name` property returns ASCII string that is UTF-8 encoded by [rfc2047](https://www.ietf.org/rfc/rfc2047.txt) if necessary;
* `hostname` property is now a human readable unicode string even if it was punycode encoded in the original parsed address;
* `to_unicode()` and `__unicode__()` functions return unicode representation where display name and hostname are decoded unicode strings.