### PR TITLE
Catch AttributeError when parsing addresses

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -129,7 +129,7 @@ def parse(address, addr_spec_only=False, strict=False, metrics=False):
                 retval._display_name = retval._display_name.decode('utf-8')
 
             mtimes['parsing'] += time() - bstart
-        except (LexError, YaccError, SyntaxError):
+        except (LexError, YaccError, SyntaxError, AttributeError):
             retval = None
             mtimes['parsing'] += time() - bstart
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.13',
+      version='0.6.14',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],


### PR DESCRIPTION
If IDNA decoding fails `_lift_parser_result` can return `None` which leads to an `AttributeError` being thrown by line 127.