### PR TITLE
Convert partial punycode

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -509,12 +509,11 @@ class EmailAddress(Address):
             self._display_name = self._display_name.decode('utf-8')
 
         # Convert localpart to unicode string.
-        # TODO consider lowercasing it here.
         if isinstance(self._mailbox, str):
             self._mailbox = self._mailbox.decode('utf-8')
 
         # Convert hostname to lowercase unicode string.
-        if self._hostname.startswith('xn--'):
+        if self._hostname.startswith('xn--') or '.xn--' in self._hostname:
             self._hostname = idna.decode(self._hostname)
         if isinstance(self._hostname, str):
             self._hostname = self._hostname.decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.13',
+      version='0.6.14',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -327,6 +327,18 @@ def test_address_convertible_2_ascii():
         'str':              u'Foo@почта.рф'.encode('utf-8'),
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
         'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
+    }, {
+        'desc': 'display_name=utf8, domain=partial-punycode',
+        'addr': u'Федот <Foo@mail.xn--com-9ma>',
+
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'address':          u'Foo@mail.comñ',
+        'ace_address':       'Foo@mail.xn--com-9ma',
+        'repr':             u'Федот <Foo@mail.comñ>'.encode('utf-8'),
+        'str':              u'Foo@mail.comñ'.encode('utf-8'),
+        'unicode':          u'Федот <Foo@mail.comñ>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@mail.xn--com-9ma>',
     }]):
         print('Test case #%d: %s' % (i, tc['desc']))
         # When


### PR DESCRIPTION
Makes the domain part of email address to be proper unicode even when some a-labels are punycode encoded but not the first one.