### PR TITLE
Quote display names before encoding them

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -529,8 +529,8 @@ class EmailAddress(Address):
 
     @property
     def ace_display_name(self):
-        return smart_quote(encode_string(None, self.display_name,
-                                         maxlinelen=MAX_ADDRESS_LENGTH))
+        return encode_string(None, smart_quote(self.display_name),
+                             maxlinelen=MAX_ADDRESS_LENGTH)
 
     @property
     def mailbox(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.14',
+      version='0.6.15',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -339,6 +339,18 @@ def test_address_convertible_2_ascii():
         'str':              u'Foo@mail.comñ'.encode('utf-8'),
         'unicode':          u'Федот <Foo@mail.comñ>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@mail.xn--com-9ma>',
+    }, {
+        'desc': 'display_name=quoted-utf8-with-specials, domain=ascii',
+        'addr': u'"Федот @ Федот" <Foo@Bar.com>',
+
+        'display_name':     u'Федот @ Федот',
+        'ace_display_name':  '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQpNC10LTQvtGCIg==?=',
+        'address':          u'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':             u'"Федот @ Федот" <Foo@bar.com>'.encode('utf-8'),
+        'str':              u'Foo@bar.com'.encode('utf-8'),
+        'unicode':          u'"Федот @ Федот" <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQpNC10LTQvtGCIg==?= <Foo@bar.com>',
     }]):
         print('Test case #%d: %s' % (i, tc['desc']))
         # When


### PR DESCRIPTION
Right now we are smart quoting display names before base64 encoding them. As a result, display names with non-ASCII characters will never be quoted since they encoded versions are always pure ASCII. Most times this is OK but if there are special characters in the display name the quotes are required.