### PR TITLE
Fixes exception when parsing bad IDNA and more

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -536,6 +536,10 @@ class EmailAddress(Address):
         return self._hostname
 
     @property
+    def ace_hostname(self):
+        return idna.encode(self._hostname)
+
+    @property
     def address(self):
         return u'{}@{}'.format(self.mailbox, self.hostname)
 

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -508,11 +508,13 @@ class EmailAddress(Address):
             self._mailbox = self._mailbox.decode('utf-8')
 
         # Convert hostname to lowercase unicode string.
+        self._hostname = self._hostname.lower()
         if self._hostname.startswith('xn--') or '.xn--' in self._hostname:
             self._hostname = idna.decode(self._hostname)
         if isinstance(self._hostname, str):
             self._hostname = self._hostname.decode('utf-8')
-        self._hostname = self._hostname.lower()
+        if not is_pure_ascii(self._hostname):
+            idna.encode(self._hostname)
 
     @property
     def addr_type(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='flanker',
-      version='0.6.15',
+      version='0.7.0',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -153,6 +153,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      '',
         'ace_display_name':  '',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':           'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':              'Foo@bar.com',
@@ -165,6 +167,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      'Blah',
         'ace_display_name':  'Blah',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':           'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':              'Blah <Foo@bar.com>',
@@ -177,6 +181,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':           'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':             u'Федот <Foo@bar.com>'.encode('utf-8'),
@@ -189,6 +195,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':           'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':             u'Федот <Foo@bar.com>'.encode('utf-8'),
@@ -201,6 +209,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':           'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>'.encode('utf-8'),
@@ -213,6 +223,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      '',
         'ace_display_name':  '',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Foo@почта.рф'.encode('utf-8'),
@@ -225,6 +237,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      'Blah',
         'ace_display_name':  'Blah',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Blah <Foo@почта.рф>'.encode('utf-8'),
@@ -237,6 +251,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
@@ -249,6 +265,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
@@ -261,6 +279,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>'.encode('utf-8'),
@@ -273,6 +293,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      '',
         'ace_display_name':  '',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Foo@почта.рф'.encode('utf-8'),
@@ -285,6 +307,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      'Blah',
         'ace_display_name':  'Blah',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Blah <Foo@почта.рф>'.encode('utf-8'),
@@ -297,6 +321,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
@@ -309,6 +335,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
@@ -321,6 +349,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
         'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>'.encode('utf-8'),
@@ -333,6 +363,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'mail.comñ',
+        'ace_hostname':      'mail.xn--com-9ma',
         'address':          u'Foo@mail.comñ',
         'ace_address':       'Foo@mail.xn--com-9ma',
         'repr':             u'Федот <Foo@mail.comñ>'.encode('utf-8'),
@@ -345,6 +377,8 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот @ Федот',
         'ace_display_name':  '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQpNC10LTQvtGCIg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':             u'"Федот @ Федот" <Foo@bar.com>'.encode('utf-8'),
@@ -360,6 +394,8 @@ def test_address_convertible_2_ascii():
         eq_(False, addr.requires_non_ascii())
         eq_(tc['display_name'], addr.display_name)
         eq_(tc['ace_display_name'], addr.ace_display_name)
+        eq_(tc['hostname'], addr.hostname)
+        eq_(tc['ace_hostname'], addr.ace_hostname)
         eq_(tc['address'], addr.address)
         eq_(tc['ace_address'], addr.ace_address)
         eq_(tc['repr'], repr(addr))
@@ -376,6 +412,8 @@ def test_address_requires_utf8():
 
         'display_name':      '',
         'ace_display_name':  '',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
         'repr':             u'Фью@bar.com'.encode('utf-8'),
         'str':              u'Фью@bar.com'.encode('utf-8'),
@@ -386,6 +424,8 @@ def test_address_requires_utf8():
 
         'display_name':      'Blah',
         'ace_display_name':  'Blah',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
         'repr':             u'Blah <Фью@bar.com>'.encode('utf-8'),
         'str':              u'Фью@bar.com'.encode('utf-8'),
@@ -396,6 +436,8 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
         'repr':             u'Федот <Фью@bar.com>'.encode('utf-8'),
         'str':              u'Фью@bar.com'.encode('utf-8'),
@@ -406,6 +448,8 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
         'repr':             u'Федот <Фью@bar.com>'.encode('utf-8'),
         'str':              u'Фью@bar.com'.encode('utf-8'),
@@ -416,6 +460,8 @@ def test_address_requires_utf8():
 
         'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'hostname':          'bar.com',
+        'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
         'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@bar.com>'.encode('utf-8'),
         'str':              u'Фью@bar.com'.encode('utf-8'),
@@ -426,6 +472,8 @@ def test_address_requires_utf8():
 
         'display_name':      '',
         'ace_display_name':  '',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'Фью@почта.рф'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -436,6 +484,8 @@ def test_address_requires_utf8():
 
         'display_name':      'Blah',
         'ace_display_name':  'Blah',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'Blah <Фью@почта.рф>'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -446,6 +496,8 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -456,6 +508,8 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -466,6 +520,8 @@ def test_address_requires_utf8():
 
         'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -476,6 +532,8 @@ def test_address_requires_utf8():
 
         'display_name':      '',
         'ace_display_name':  '',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'Фью@почта.рф'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -486,6 +544,8 @@ def test_address_requires_utf8():
 
         'display_name':     'Blah',
         'ace_display_name': 'Blah',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':         u'Фью@почта.рф',
         'repr':            u'Blah <Фью@почта.рф>'.encode('utf-8'),
         'str':             u'Фью@почта.рф'.encode('utf-8'),
@@ -496,6 +556,8 @@ def test_address_requires_utf8():
 
         'display_name':    u'Федот',
         'ace_display_name': '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':         u'Фью@почта.рф',
         'repr':            u'Федот <Фью@почта.рф>'.encode('utf-8'),
         'str':             u'Фью@почта.рф'.encode('utf-8'),
@@ -506,6 +568,8 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -516,6 +580,8 @@ def test_address_requires_utf8():
 
         'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
+        'hostname':         u'почта.рф',
+        'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
         'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>'.encode('utf-8'),
         'str':              u'Фью@почта.рф'.encode('utf-8'),
@@ -529,6 +595,8 @@ def test_address_requires_utf8():
         eq_(True, addr.requires_non_ascii())
         eq_(tc['display_name'], addr.display_name)
         eq_(tc['ace_display_name'], addr.ace_display_name)
+        eq_(tc['hostname'], addr.hostname)
+        eq_(tc['ace_hostname'], addr.ace_hostname)
         eq_(tc['address'], addr.address)
         with assert_raises(ValueError):
             _ = addr.ace_address

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -151,11 +151,11 @@ def test_address_convertible_2_ascii():
         'desc': 'display_name=empty, domain=ascii',
         'addr': 'Foo@Bar.com',
 
-        'display_name':      '',
+        'display_name':     u'',
         'ace_display_name':  '',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
-        'address':           'Foo@bar.com',
+        'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':              'Foo@bar.com',
         'str':               'Foo@bar.com',
@@ -165,11 +165,11 @@ def test_address_convertible_2_ascii():
         'desc': 'display_name=ascii, domain=ascii',
         'addr': 'Blah <Foo@Bar.com>',
 
-        'display_name':      'Blah',
+        'display_name':     u'Blah',
         'ace_display_name':  'Blah',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
-        'address':           'Foo@bar.com',
+        'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
         'repr':              'Blah <Foo@bar.com>',
         'str':               'Foo@bar.com',
@@ -181,11 +181,11 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
-        'address':           'Foo@bar.com',
+        'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
-        'repr':             u'Федот <Foo@bar.com>'.encode('utf-8'),
+        'repr':              'Федот <Foo@bar.com>',
         'str':               'Foo@bar.com',
         'unicode':          u'Федот <Foo@bar.com>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@bar.com>',
@@ -195,11 +195,11 @@ def test_address_convertible_2_ascii():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
-        'address':           'Foo@bar.com',
+        'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
-        'repr':             u'Федот <Foo@bar.com>'.encode('utf-8'),
+        'repr':              'Федот <Foo@bar.com>',
         'str':               'Foo@bar.com',
         'unicode':          u'Федот <Foo@bar.com>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@bar.com>',
@@ -207,13 +207,13 @@ def test_address_convertible_2_ascii():
         'desc': 'display_name=bad-encoding, domain=ascii',
         'addr': '=?blah0KTQtdC00L7Rgg==?= <Foo@Bar.com>',
 
-        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'display_name':     u'=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
-        'address':           'Foo@bar.com',
+        'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
-        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>'.encode('utf-8'),
+        'repr':              '=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>',
         'str':               'Foo@bar.com',
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>',
         'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@bar.com>',
@@ -221,28 +221,28 @@ def test_address_convertible_2_ascii():
         'desc': 'display_name=empty, domain=utf8',
         'addr': u'Foo@Почта.рф',
 
-        'display_name':      '',
+        'display_name':     u'',
         'ace_display_name':  '',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Foo@почта.рф'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Foo@почта.рф',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Foo@почта.рф',
         'full_spec':         'Foo@xn--80a1acny.xn--p1ai',
     }, {
         'desc': 'display_name=ascii, domain=utf8',
         'addr': u'Blah <Foo@Почта.рф>',
 
-        'display_name':      'Blah',
+        'display_name':     u'Blah',
         'ace_display_name':  'Blah',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Blah <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Blah <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Blah <Foo@почта.рф>',
         'full_spec':         'Blah <Foo@xn--80a1acny.xn--p1ai>',
     }, {
@@ -255,8 +255,8 @@ def test_address_convertible_2_ascii():
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Федот <Foo@почта.рф>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
@@ -269,50 +269,50 @@ def test_address_convertible_2_ascii():
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Федот <Foo@почта.рф>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
         'desc': 'display_name=bad-encoding, domain=utf8',
         'addr': u'=?blah0KTQtdC00L7Rgg==?= <Foo@Почта.рф>',
 
-        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'display_name':     u'=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              '=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
         'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
         'desc': 'display_name=empty, domain=punycode',
         'addr': 'Foo@xn--80a1acny.xn--p1ai',
 
-        'display_name':      '',
+        'display_name':     u'',
         'ace_display_name':  '',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Foo@почта.рф'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Foo@почта.рф',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Foo@почта.рф',
         'full_spec':         'Foo@xn--80a1acny.xn--p1ai',
     }, {
         'desc': 'display_name=ascii, domain=punycode',
         'addr': 'Blah <Foo@xn--80a1acny.xn--p1ai>',
 
-        'display_name':      'Blah',
+        'display_name':     u'Blah',
         'ace_display_name':  'Blah',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Blah <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Blah <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Blah <Foo@почта.рф>',
         'full_spec':         'Blah <Foo@xn--80a1acny.xn--p1ai>',
     }, {
@@ -325,8 +325,8 @@ def test_address_convertible_2_ascii():
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Федот <Foo@почта.рф>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
@@ -339,22 +339,22 @@ def test_address_convertible_2_ascii():
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'Федот <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'Федот <Foo@почта.рф>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
         'desc': 'display_name=bad-encoding, domain=punycode',
         'addr': '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
 
-        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'display_name':     u'=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Foo@почта.рф',
         'ace_address':       'Foo@xn--80a1acny.xn--p1ai',
-        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>'.encode('utf-8'),
-        'str':              u'Foo@почта.рф'.encode('utf-8'),
+        'repr':              '=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
+        'str':               'Foo@почта.рф',
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Foo@почта.рф>',
         'full_spec':         '=?blah0KTQtdC00L7Rgg==?= <Foo@xn--80a1acny.xn--p1ai>',
     }, {
@@ -367,42 +367,42 @@ def test_address_convertible_2_ascii():
         'ace_hostname':      'mail.xn--com-9ma',
         'address':          u'Foo@mail.comñ',
         'ace_address':       'Foo@mail.xn--com-9ma',
-        'repr':             u'Федот <Foo@mail.comñ>'.encode('utf-8'),
-        'str':              u'Foo@mail.comñ'.encode('utf-8'),
+        'repr':              'Федот <Foo@mail.comñ>',
+        'str':               'Foo@mail.comñ',
         'unicode':          u'Федот <Foo@mail.comñ>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@mail.xn--com-9ma>',
     }, {
         'desc': 'display_name=quoted-utf8-with-specials, domain=ascii',
-        'addr': u'"Федот @ Федот" <Foo@Bar.com>',
+        'addr': u'"Федот @ Стрелец" <Foo@Bar.com>',
 
-        'display_name':     u'Федот @ Федот',
-        'ace_display_name':  '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQpNC10LTQvtGCIg==?=',
-        'hostname':          'bar.com',
+        'display_name':     u'Федот @ Стрелец',
+        'ace_display_name':  '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?=',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
         'address':          u'Foo@bar.com',
         'ace_address':       'Foo@bar.com',
-        'repr':             u'"Федот @ Федот" <Foo@bar.com>'.encode('utf-8'),
-        'str':              u'Foo@bar.com'.encode('utf-8'),
-        'unicode':          u'"Федот @ Федот" <Foo@bar.com>',
-        'full_spec':         '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQpNC10LTQvtGCIg==?= <Foo@bar.com>',
+        'repr':              '"Федот @ Стрелец" <Foo@bar.com>',
+        'str':               'Foo@bar.com',
+        'unicode':          u'"Федот @ Стрелец" <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <Foo@bar.com>',
     }]):
         print('Test case #%d: %s' % (i, tc['desc']))
         # When
         addr = parse(tc['addr'])
         # Then
         assert isinstance(addr, EmailAddress)
-        eq_(False, addr.requires_non_ascii())
-        eq_(tc['display_name'], addr.display_name)
-        eq_(tc['ace_display_name'], addr.ace_display_name)
-        eq_(tc['hostname'], addr.hostname)
-        eq_(tc['ace_hostname'], addr.ace_hostname)
-        eq_(tc['address'], addr.address)
-        eq_(tc['ace_address'], addr.ace_address)
-        eq_(tc['repr'], repr(addr))
-        eq_(tc['str'], str(addr))
-        eq_(tc['unicode'], unicode(addr))
-        eq_(tc['unicode'], addr.to_unicode())
-        eq_(tc['full_spec'], addr.full_spec())
+        _typed_eq(False, addr.requires_non_ascii())
+        _typed_eq(tc['display_name'], addr.display_name)
+        _typed_eq(tc['ace_display_name'], addr.ace_display_name)
+        _typed_eq(tc['hostname'], addr.hostname)
+        _typed_eq(tc['ace_hostname'], addr.ace_hostname)
+        _typed_eq(tc['address'], addr.address)
+        _typed_eq(tc['ace_address'], addr.ace_address)
+        _typed_eq(tc['repr'], repr(addr))
+        _typed_eq(tc['str'], str(addr))
+        _typed_eq(tc['unicode'], unicode(addr))
+        _typed_eq(tc['unicode'], addr.to_unicode())
+        _typed_eq(tc['full_spec'], addr.full_spec())
 
 
 def test_address_requires_utf8():
@@ -410,25 +410,25 @@ def test_address_requires_utf8():
         'desc': 'display_name=empty, domain=ascii',
         'addr': u'Фью@Bar.com',
 
-        'display_name':      '',
+        'display_name':     u'',
         'ace_display_name':  '',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
-        'repr':             u'Фью@bar.com'.encode('utf-8'),
-        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'repr':              'Фью@bar.com',
+        'str':               'Фью@bar.com',
         'unicode':          u'Фью@bar.com',
     }, {
         'desc': 'display_name=ascii, domain=ascii',
         'addr': u'Blah <Фью@Bar.com>',
 
-        'display_name':      'Blah',
+        'display_name':     u'Blah',
         'ace_display_name':  'Blah',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
-        'repr':             u'Blah <Фью@bar.com>'.encode('utf-8'),
-        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'repr':              'Blah <Фью@bar.com>',
+        'str':               'Фью@bar.com',
         'unicode':          u'Blah <Фью@bar.com>',
     }, {
         'desc': 'display_name=utf8, domain=ascii',
@@ -436,11 +436,11 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
-        'repr':             u'Федот <Фью@bar.com>'.encode('utf-8'),
-        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'repr':              'Федот <Фью@bar.com>',
+        'str':               'Фью@bar.com',
         'unicode':          u'Федот <Фью@bar.com>',
     }, {
         'desc': 'display_name=encoded-utf8, domain=ascii',
@@ -448,47 +448,47 @@ def test_address_requires_utf8():
 
         'display_name':     u'Федот',
         'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
-        'repr':             u'Федот <Фью@bar.com>'.encode('utf-8'),
-        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'repr':              'Федот <Фью@bar.com>',
+        'str':               'Фью@bar.com',
         'unicode':          u'Федот <Фью@bar.com>',
     }, {
         'desc': 'display_name=bad-encoding, domain=ascii',
         'addr': u'=?blah0KTQtdC00L7Rgg==?= <Фью@Bar.com>',
 
-        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'display_name':     u'=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
-        'hostname':          'bar.com',
+        'hostname':         u'bar.com',
         'ace_hostname':      'bar.com',
         'address':          u'Фью@bar.com',
-        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@bar.com>'.encode('utf-8'),
-        'str':              u'Фью@bar.com'.encode('utf-8'),
+        'repr':              '=?blah0KTQtdC00L7Rgg==?= <Фью@bar.com>',
+        'str':               'Фью@bar.com',
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Фью@bar.com>',
     }, {
         'desc': 'display_name=empty, domain=utf8',
         'addr': u'Фью@Почта.рф',
 
-        'display_name':      '',
+        'display_name':     u'',
         'ace_display_name':  '',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'Фью@почта.рф'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              'Фью@почта.рф',
+        'str':               'Фью@почта.рф',
         'unicode':          u'Фью@почта.рф',
     }, {
         'desc': 'display_name=ascii, domain=utf8',
         'addr': u'Blah <Фью@Почта.рф>',
 
-        'display_name':      'Blah',
+        'display_name':     u'Blah',
         'ace_display_name':  'Blah',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'Blah <Фью@почта.рф>'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              'Blah <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
         'unicode':          u'Blah <Фью@почта.рф>',
     }, {
         'desc': 'display_name=utf8, domain=utf8',
@@ -499,8 +499,8 @@ def test_address_requires_utf8():
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
         'unicode':          u'Федот <Фью@почта.рф>',
     }, {
         'desc': 'display_name=encoded-utf8, domain=utf8',
@@ -511,57 +511,57 @@ def test_address_requires_utf8():
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
         'unicode':          u'Федот <Фью@почта.рф>',
     }, {
         'desc': 'display_name=bad-encoding, domain=utf8',
         'addr': u'=?blah0KTQtdC00L7Rgg==?= <Фью@Почта.рф>',
 
-        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'display_name':     u'=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              '=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>',
     }, {
         'desc': 'display_name=empty, domain=punycode',
         'addr': u'Фью@xn--80a1acny.xn--p1ai',
 
-        'display_name':      '',
+        'display_name':     u'',
         'ace_display_name':  '',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'Фью@почта.рф'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              'Фью@почта.рф',
+        'str':               'Фью@почта.рф',
         'unicode':          u'Фью@почта.рф',
     }, {
         'desc': 'display_name=ascii, domain=punycode',
         'addr': u'Blah <Фью@xn--80a1acny.xn--p1ai>',
 
-        'display_name':     'Blah',
-        'ace_display_name': 'Blah',
+        'display_name':     u'Blah',
+        'ace_display_name':  'Blah',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
-        'address':         u'Фью@почта.рф',
-        'repr':            u'Blah <Фью@почта.рф>'.encode('utf-8'),
-        'str':             u'Фью@почта.рф'.encode('utf-8'),
-        'unicode':         u'Blah <Фью@почта.рф>',
+        'address':          u'Фью@почта.рф',
+        'repr':              'Blah <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
+        'unicode':          u'Blah <Фью@почта.рф>',
     }, {
         'desc': 'display_name=utf8, domain=punycode',
         'addr': u'Федот <Фью@xn--80a1acny.xn--p1ai>',
 
-        'display_name':    u'Федот',
-        'ace_display_name': '=?utf-8?b?0KTQtdC00L7Rgg==?=',
+        'display_name':     u'Федот',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7Rgg==?=',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
-        'address':         u'Фью@почта.рф',
-        'repr':            u'Федот <Фью@почта.рф>'.encode('utf-8'),
-        'str':             u'Фью@почта.рф'.encode('utf-8'),
-        'unicode':         u'Федот <Фью@почта.рф>',
+        'address':          u'Фью@почта.рф',
+        'repr':              'Федот <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
+        'unicode':          u'Федот <Фью@почта.рф>',
     }, {
         'desc': 'display_name=encoded-utf8, domain=punycode',
         'addr': u'=?utf-8?b?0KTQtdC00L7Rgg==?= <Фью@xn--80a1acny.xn--p1ai>',
@@ -571,20 +571,20 @@ def test_address_requires_utf8():
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'Федот <Фью@почта.рф>'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              'Федот <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
         'unicode':          u'Федот <Фью@почта.рф>',
     }, {
         'desc': 'display_name=bad-encoding, domain=punycode',
         'addr': u'=?blah0KTQtdC00L7Rgg==?= <Фью@xn--80a1acny.xn--p1ai>',
 
-        'display_name':      '=?blah0KTQtdC00L7Rgg==?=',
+        'display_name':     u'=?blah0KTQtdC00L7Rgg==?=',
         'ace_display_name':  '=?blah0KTQtdC00L7Rgg==?=',
         'hostname':         u'почта.рф',
         'ace_hostname':      'xn--80a1acny.xn--p1ai',
         'address':          u'Фью@почта.рф',
-        'repr':             u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>'.encode('utf-8'),
-        'str':              u'Фью@почта.рф'.encode('utf-8'),
+        'repr':              '=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>',
+        'str':               'Фью@почта.рф',
         'unicode':          u'=?blah0KTQtdC00L7Rgg==?= <Фью@почта.рф>',
     }]):
         print('Test case #%d: %s' % (i, tc['desc']))
@@ -592,29 +592,39 @@ def test_address_requires_utf8():
         addr = parse(tc['addr'])
         # Then
         assert isinstance(addr, EmailAddress)
-        eq_(True, addr.requires_non_ascii())
-        eq_(tc['display_name'], addr.display_name)
-        eq_(tc['ace_display_name'], addr.ace_display_name)
-        eq_(tc['hostname'], addr.hostname)
-        eq_(tc['ace_hostname'], addr.ace_hostname)
-        eq_(tc['address'], addr.address)
+        _typed_eq(True, addr.requires_non_ascii())
+        _typed_eq(tc['display_name'], addr.display_name)
+        _typed_eq(tc['ace_display_name'], addr.ace_display_name)
+        _typed_eq(tc['hostname'], addr.hostname)
+        _typed_eq(tc['ace_hostname'], addr.ace_hostname)
+        _typed_eq(tc['address'], addr.address)
         with assert_raises(ValueError):
             _ = addr.ace_address
-        eq_(tc['repr'], repr(addr))
-        eq_(tc['str'], str(addr))
-        eq_(tc['unicode'], unicode(addr))
-        eq_(tc['unicode'], addr.to_unicode())
+        _typed_eq(tc['repr'], repr(addr))
+        _typed_eq(tc['str'], str(addr))
+        _typed_eq(tc['unicode'], unicode(addr))
+        _typed_eq(tc['unicode'], addr.to_unicode())
         with assert_raises(ValueError):
             addr.full_spec()
 
 
-def test_parse_bad_address():
+def test_parse_bad_idna():
+    # Some unicode addresses may seem ok at first sight, but in fact be invalid
+    # because they contain not allowed unicode characters. Regardless whether
+    # they are presented in punycode or UTF-8 form.
+
     for i, tc in enumerate([{
-        'desc': 'Invalid IDNA domain',
-        'addr': 'n1a2m3@xn--eckwd4c7c.xn--8sd3676g',
+        'desc': 'Invalid IDNA domain (punycode)',
+        'addr': 'foo@xn--eckwd4c7c.xn--8sd3676g',
+    }, {
+        'desc': 'Invalid IDNA domain (UTF-8)',
+        'addr': 'foo@ドメイン.채ᅳ',
     }, {
         'desc': 'Invalid IDNA alabel',
-        'addr': 'stay@reluctantpanther.xn--com-to0a',
+        'addr': 'foo@bar.xn--com-to0a',
+    }, {
+        'desc': 'Invalid IDNA ulabel',
+        'addr': 'foo@bar.com’',
     }]):
         print('Test case #%d: %s' % (i, tc['desc']))
         # When/Then
@@ -685,3 +695,8 @@ def test_parse_list_relaxed():
     addr_list = ['foo <foo@bar.com>', 'foo foo@bar.com', 'not@valid <foo@bar.com>']
     expected = ['foo <foo@bar.com>', 'foo <foo@bar.com>', '"not@valid" <foo@bar.com>']
     eq_(expected, [addr.to_unicode() for addr in parse_list(addr_list)])
+
+
+def _typed_eq(lhs, rhs):
+    eq_(lhs, rhs)
+    eq_(type(lhs), type(rhs))

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -540,6 +540,19 @@ def test_address_requires_utf8():
             addr.full_spec()
 
 
+def test_parse_bad_address():
+    for i, tc in enumerate([{
+        'desc': 'Invalid IDNA domain',
+        'addr': 'n1a2m3@xn--eckwd4c7c.xn--8sd3676g',
+    }, {
+        'desc': 'Invalid IDNA alabel',
+        'addr': 'stay@reluctantpanther.xn--com-to0a',
+    }]):
+        print('Test case #%d: %s' % (i, tc['desc']))
+        # When/Then
+        eq_(None, parse(tc['addr']))
+
+
 def test_address_properties_req_utf8():
     for i, tc in enumerate([{
         'desc': 'utf8',

--- a/tests/addresslib/parser_address_list_test.py
+++ b/tests/addresslib/parser_address_list_test.py
@@ -2,17 +2,21 @@
 
 from itertools import chain, combinations, permutations
 
-from nose.tools import assert_equal, assert_not_equal
+from nose.tools import assert_equal, assert_not_equal, assert_raises
 from nose.tools import nottest
 
-from flanker.addresslib.address import EmailAddress, AddressList, parse_list
+from flanker.addresslib.address import EmailAddress, AddressList, parse_list, \
+    parse
 
 
 @nottest
 def powerset(iterable):
-    "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+    """
+    powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)
+    """
     s = list(iterable)
     return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
+
 
 @nottest
 def run_test(string, expected_mlist):
@@ -192,3 +196,14 @@ def test_delimiters():
 
         addr_string = 'bill@microsoft.com' + ''.join(e) + 'steve@apple.com, torvalds@kernel.org'
         run_test(addr_string, [BILL_AS, STEVE_AS, LINUS_AS])
+
+
+def test_append_address_only():
+    # Only Address types can be added to an AddressList.
+
+    al = AddressList()
+    al.append(parse(u'Федот <стрелец@почта.рф>'))
+    al.append(parse('https://mailgun.net/webhooks'))
+
+    with assert_raises(TypeError):
+        al.append('foo@bar.com')


### PR DESCRIPTION
Make three unrelated changes:
1. Fixes `AttributeError: 'NoneType' object has no attribute '_display_name'` exception when parsing an address that has an invalid IDNA alabel;
2. Enforces AddressList to only contain Address objects;
3. Introduces EmailAddress.ace_hostname property to return pure-ASCII representation of the domain part;