### PR TITLE
Decode display names before unquoting them

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -495,13 +495,13 @@ class EmailAddress(Address):
             raise SyntaxError('failed to create EmailAddress: bad parameters')
 
         # Convert display name to decoded unicode string.
+        if (self._display_name.startswith('=?') and
+                self._display_name.endswith('?=')):
+            self._display_name = mime_to_unicode(self._display_name)
         if (self._display_name.startswith('"') and
                 self._display_name.endswith('"') and
                 len(self._display_name) > 2):
             self._display_name = smart_unquote(self._display_name)
-        if (self._display_name.startswith('=?') and
-                self._display_name.endswith('?=')):
-            self._display_name = mime_to_unicode(self._display_name)
         if isinstance(self._display_name, str):
             self._display_name = self._display_name.decode('utf-8')
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='flanker',
-      version='0.7.1',
+      version='0.7.2',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -385,6 +385,20 @@ def test_address_convertible_2_ascii():
         'str':               'Foo@bar.com',
         'unicode':          u'"Федот @ Стрелец" <Foo@bar.com>',
         'full_spec':         '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <Foo@bar.com>',
+    }, {
+        'desc': 'display_name=quoted-and-encoded-utf8-with-specials, domain=ascii',
+        'addr': u'=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <Foo@Bar.com>',
+
+        'display_name':     u'Федот @ Стрелец',
+        'ace_display_name':  '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?=',
+        'hostname':         u'bar.com',
+        'ace_hostname':      'bar.com',
+        'address':          u'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':              '"Федот @ Стрелец" <Foo@bar.com>',
+        'str':               'Foo@bar.com',
+        'unicode':          u'"Федот @ Стрелец" <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <Foo@bar.com>',
     }]):
         print('Test case #%d: %s' % (i, tc['desc']))
         # When


### PR DESCRIPTION
When we parse addresses we need to decode display names before we attempt to unquote them. If we do this in the wrong order the quotes aren't removed and the display name will be quoted twice (or more...).

Before:
```
Python 2.7.6 (default, Feb 21 2017, 11:05:11)
[GCC 6.3.1 20161221 (Red Hat 6.3.1-1)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from flanker.addresslib.address import parse
>>> parse('"Федот @ Стрелец" <test@example.com>').full_spec()
'=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <test@example.com>'
>>> parse('=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <test@example.com>')
"\"Федот @ Стрелец\"" <test@example.com>
```

After:
```
Python 2.7.6 (default, Feb 21 2017, 11:05:11)
[GCC 6.3.1 20161221 (Red Hat 6.3.1-1)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from flanker.addresslib.address import parse
>>> parse('"Федот @ Стрелец" <test@example.com>').full_spec()
'=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <test@example.com>'
>>> parse('=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <test@example.com>')
"Федот @ Стрелец" <test@example.com>
```