### PR TITLE
Don't quote periods in display names

### DIFF
--- a/flanker/addresslib/quote.py
+++ b/flanker/addresslib/quote.py
@@ -3,7 +3,7 @@ import re
 from flanker.addresslib.lexer import t_ATOM, t_FWSP
 
 _RE_ATOM_PHRASE = re.compile(
-    r'({atom}({fwsp}{atom})*)?'.format(atom=t_ATOM, fwsp=t_FWSP),
+    r'(({atom}|\.)+({fwsp}({atom}|\.)+)*)?'.format(atom=t_ATOM, fwsp=t_FWSP),
     re.MULTILINE | re.VERBOSE)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='flanker',
-      version='0.7.2',
+      version='0.7.3',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -138,7 +138,7 @@ def test_edge_cases():
 def test_display_name__to_full_spec():
     eq_('"foo (\\"bar\\") blah" <foo@bar.com>',
         EmailAddress('foo ("bar") blah', 'foo@bar.com').full_spec())
-    eq_('"foo. bar" <foo@bar.com>',
+    eq_('foo. bar <foo@bar.com>',
         EmailAddress('foo. bar', 'foo@bar.com').full_spec())
     eq_('"\\"\\"" <foo@bar.com>',
         EmailAddress('""', 'foo@bar.com').full_spec()),

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -372,7 +372,21 @@ def test_address_convertible_2_ascii():
         'unicode':          u'Федот <Foo@mail.comñ>',
         'full_spec':         '=?utf-8?b?0KTQtdC00L7Rgg==?= <Foo@mail.xn--com-9ma>',
     }, {
-        'desc': 'display_name=quoted-utf8-with-specials, domain=ascii',
+        'desc': 'display_name=quoted-utf8-with-period, domain=ascii',
+        'addr': u'"Федот . Стрелец" <Foo@Bar.com>',
+
+        'display_name':     u'Федот . Стрелец',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7RgiAuINCh0YLRgNC10LvQtdGG?=',
+        'hostname':         u'bar.com',
+        'ace_hostname':      'bar.com',
+        'address':          u'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':              'Федот . Стрелец <Foo@bar.com>',
+        'str':               'Foo@bar.com',
+        'unicode':          u'Федот . Стрелец <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7RgiAuINCh0YLRgNC10LvQtdGG?= <Foo@bar.com>',
+    }, {
+        'desc': 'display_name=quoted-utf8-with-special, domain=ascii',
         'addr': u'"Федот @ Стрелец" <Foo@Bar.com>',
 
         'display_name':     u'Федот @ Стрелец',
@@ -386,7 +400,21 @@ def test_address_convertible_2_ascii():
         'unicode':          u'"Федот @ Стрелец" <Foo@bar.com>',
         'full_spec':         '=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <Foo@bar.com>',
     }, {
-        'desc': 'display_name=quoted-and-encoded-utf8-with-specials, domain=ascii',
+        'desc': 'display_name=quoted-and-encoded-utf8-with-period, domain=ascii',
+        'addr': u'=?utf-8?b?ItCk0LXQtNC+0YIgLiDQodGC0YDQtdC70LXRhiI=?= <Foo@Bar.com>',
+
+        'display_name':     u'Федот . Стрелец',
+        'ace_display_name':  '=?utf-8?b?0KTQtdC00L7RgiAuINCh0YLRgNC10LvQtdGG?=',
+        'hostname':         u'bar.com',
+        'ace_hostname':      'bar.com',
+        'address':          u'Foo@bar.com',
+        'ace_address':       'Foo@bar.com',
+        'repr':              'Федот . Стрелец <Foo@bar.com>',
+        'str':               'Foo@bar.com',
+        'unicode':          u'Федот . Стрелец <Foo@bar.com>',
+        'full_spec':         '=?utf-8?b?0KTQtdC00L7RgiAuINCh0YLRgNC10LvQtdGG?= <Foo@bar.com>',
+    }, {
+        'desc': 'display_name=quoted-and-encoded-utf8-with-special, domain=ascii',
         'addr': u'=?utf-8?b?ItCk0LXQtNC+0YIgQCDQodGC0YDQtdC70LXRhiI=?= <Foo@Bar.com>',
 
         'display_name':     u'Федот @ Стрелец',

--- a/tests/addresslib/quote_test.py
+++ b/tests/addresslib/quote_test.py
@@ -9,8 +9,11 @@ def test_quote():
     eq_('"foo< bar"', smart_quote('foo< bar'))
     eq_('"foo> bar"', smart_quote('foo> bar'))
     eq_('"foo\\" bar"', smart_quote('foo" bar'))
-    eq_('"foo. bar"', smart_quote('foo. bar'))
     eq_('"foo: bar"', smart_quote('foo: bar'))
+
+
+def test_quote__periods():
+    eq_('foo. bar', smart_quote('foo. bar'))
 
 
 def test_quote__spaces():


### PR DESCRIPTION
Some email clients will add quotes to display names when they are base64 encoded and also contain special characters. This is causing some unexpected twice-quoted display names (`"\"foo.\""`) for some of our customers. This PR should fix that at least for display names containing periods. The display names should all still parse, possibly using the obsolete phrase syntax.