### PR TITLE
Accept non-ascii attachment name

### DIFF
--- a/flanker/mime/message/headers/parametrized.py
+++ b/flanker/mime/message/headers/parametrized.py
@@ -256,7 +256,7 @@ _RE_HEADER_VALUE = re.compile(r'''
        # don't care about the spaces
        ^[\ \t]*
        #main type and sub type or any other value
-       ([a-z0-9\-/\.\*]+)
+       ([^\ \t;]+)
        # grab the trailing spaces, colons
        [\ \t;]*''', re.IGNORECASE | re.VERBOSE)
 
@@ -307,7 +307,8 @@ _RE_NEW_STYLE_PARAM = re.compile(r'''
      (?P<value>
        (?:
          "(?:
-             [\x21\x23-\x5b\x5d-\x7e\ \t]
+             # so this works for unicode too
+             [^\x00-\x10\x12-\x19\x22\x5c\x7f]
              |
              (?:\\[\x21-\x7e\t\ ])
           )+"

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -37,13 +37,11 @@ def parse_header(header):
 
 def parse_header_value(name, val):
     if not is_pure_ascii(val):
-        if parametrized.is_parametrized(name, val):
-            raise DecodingError('Unsupported value in content- header')
-
-        return to_unicode(val)
-
+        val = to_unicode(val)
     if parametrized.is_parametrized(name, val):
         val, params = parametrized.decode(val)
+        if val is not None and not is_pure_ascii(val):
+            raise DecodingError('Non-ascii content header value')
         if name == 'Content-Type':
             main, sub = parametrized.fix_content_type(val)
             return ContentType(main, sub, params)

--- a/tests/mime/message/fallback/fallback_test.py
+++ b/tests/mime/message/fallback/fallback_test.py
@@ -93,7 +93,9 @@ def message_content_dispositions_test():
 
     message = create.from_string("Content-Disposition: Нельзя распарсить")
     parts = list(message.walk(with_self=True))
-    eq_((None, {}), parts[0].content_disposition)
+    # content disposition value is anything (including unicode chars) up to the first space, tab or semicolon
+    # but non-ascii value will raise DecodeError
+    eq_(('Нельзя', {}), parts[0].content_disposition)
 
 
 def message_from_python_test():

--- a/tests/mime/message/part_test.py
+++ b/tests/mime/message/part_test.py
@@ -351,11 +351,15 @@ def to_string_test():
     ok_(str(scan(TORTURE)))
 
 
-# Yahoo fails with russian attachments.
 def broken_ctype_test():
     message = scan(RUSSIAN_ATTACH_YAHOO)
-    assert_raises(
-        DecodingError, lambda x: [p.headers for p in message.walk()], 1)
+    attachment = message.parts[1]
+    eq_('image/png', attachment.detected_content_type)
+    eq_('png', attachment.detected_subtype)
+    eq_('image', attachment.detected_format)
+    eq_(u'Картинка с очень, очень длинным предлинным именем преименем таким чт�', attachment.detected_file_name)
+    ok_(not attachment.is_body())
+
 
 def read_attach_test():
     message = scan(MAILGUN_PIC)


### PR DESCRIPTION
Non-ascii param will no longer raise DecodingError, as shown in the
old broken_ctype_test. This bug can be reproduced by sending an
attachment in gmail with non-ascii name.
The bug is fixed by tuning regex. Non-ascii params still have to be
double quoted.