### PR TITLE
Fix bounce detection for office365

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
   - 2.7
+  - 3.5
+  - 3.6
 install:
   - pip install -e .[validator]
   - pip install nose mock coverage coveralls
-script:
-  - nosetests --with-coverage --cover-package=flanker
+script: ./build.sh
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.5
   - 3.6
 install:
   - pip install -e .[validator]

--- a/build.sh
+++ b/build.sh
@@ -7,12 +7,13 @@ set -u
 if [[ ${TRAVIS_PYTHON_VERSION} == 2.7* ]]; then
     nosetests --with-coverage --cover-package=flanker
 else
-    nosetests --with-coverage --cover-package=flanker tests/mime/bounce_tests.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/threading_test.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/tokenizer_test.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/encodedword_test.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/headers_test.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/parametrized_test.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/parsing_test.py
-    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/wrappers_test.py
+    nosetests --with-coverage --cover-package=flanker \
+        tests/mime/bounce_tests.py \
+        tests/mime/message/threading_test.py \
+        tests/mime/message/tokenizer_test.py \
+        tests/mime/message/headers/encodedword_test.py \
+        tests/mime/message/headers/headers_test.py \
+        tests/mime/message/headers/parametrized_test.py \
+        tests/mime/message/headers/parsing_test.py \
+        tests/mime/message/headers/wrappers_test.py
 fi

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,6 @@ if [[ ${TRAVIS_PYTHON_VERSION} == 2.7* ]]; then
     nosetests --with-coverage --cover-package=flanker
 else
     nosetests --with-coverage --cover-package=flanker tests/mime/bounce_tests.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/threading_test.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/tokenizer_test.py
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Make sure the script fails fast.
+set -e
+set -u
+
+if [[ ${TRAVIS_PYTHON_VERSION} == 2.7* ]]; then
+    nosetests --with-coverage --cover-package=flanker
+else
+    nosetests --with-coverage --cover-package=flanker tests/mime/bounce_tests.py
+fi

--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,9 @@ else
     nosetests --with-coverage --cover-package=flanker tests/mime/bounce_tests.py
     nosetests --with-coverage --cover-package=flanker tests/mime/message/threading_test.py
     nosetests --with-coverage --cover-package=flanker tests/mime/message/tokenizer_test.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/encodedword_test.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/headers_test.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/parametrized_test.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/parsing_test.py
+    nosetests --with-coverage --cover-package=flanker tests/mime/message/headers/wrappers_test.py
 fi

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -35,12 +35,12 @@ See the parser.py module for implementation details of the parser.
 """
 from logging import getLogger
 from time import time
-from urlparse import urlparse
 
 import idna
 from idna import IDNAError
 from ply.lex import LexError
 from ply.yacc import YaccError
+from six.moves.urllib_parse import urlparse
 
 from flanker.addresslib.lexer import lexer
 from flanker.addresslib.parser import (Mailbox, Url, mailbox_parser,

--- a/flanker/addresslib/parser.py
+++ b/flanker/addresslib/parser.py
@@ -1,8 +1,9 @@
-import ply.yacc as yacc
-from lexer import tokens, lexer
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
+import ply.yacc as yacc
+
+from flanker.addresslib.lexer import lexer, tokens
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -189,16 +190,16 @@ if __name__ == '__main__':
             break
         if s == '': continue
 
-        print '\nTokens list:\n'
+        print('\nTokens list:\n')
         lexer.input(s)
         while True:
             tok = lexer.token()
             if not tok:
                 break
-            print tok
+            print(tok)
 
-        print '\nParsing behavior:\n'
+        print('\nParsing behavior:\n')
         result = mailbox_or_url_list_parser.parse(s, debug=log)
 
-        print '\nResult:\n'
-        print result
+        print('\nResult:\n')
+        print(result)

--- a/flanker/addresslib/quote.py
+++ b/flanker/addresslib/quote.py
@@ -1,5 +1,7 @@
-from StringIO import StringIO
-import re
+import regex as re
+import six
+from six.moves import StringIO
+
 from flanker.addresslib.lexer import t_ATOM, t_FWSP
 
 _RE_ATOM_PHRASE = re.compile(
@@ -50,7 +52,7 @@ def smart_unquote(s):
 
 
 def _contains_atoms_only(s):
-    if isinstance(s, unicode):
+    if isinstance(s, six.text_type):
         s = s.encode('utf-8')
     match_result = _RE_ATOM_PHRASE.match(s)
     return match_result and match_result.end(0) == len(s)

--- a/flanker/addresslib/tokenizer.py
+++ b/flanker/addresslib/tokenizer.py
@@ -26,7 +26,7 @@ WHITESPACE = re.compile(r'''
                         (\ |\t)+                                # whitespace
                         ''', re.MULTILINE | re.VERBOSE)
 
-UNI_WHITE  = re.compile(ur'''
+UNI_WHITE  = re.compile(u'''
                         [
                             \u0020\u00a0\u1680\u180e
                             \u2000-\u200a
@@ -47,11 +47,11 @@ DOT_ATOM   = re.compile(r'''
                         (\.[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~]+)*   # (dot atext)*
                         ''', re.MULTILINE | re.VERBOSE)
 
-UNI_ATOM = re.compile(ur'''
+UNI_ATOM = re.compile(r'''
                         ([^\s<>;,"]+)
                         ''', re.MULTILINE | re.VERBOSE | re.UNICODE)
 
-UNI_QSTR   = re.compile(ur'''
+UNI_QSTR   = re.compile(r'''
                         "
                         (?P<qstr>([^"]+))
                         "

--- a/flanker/mime/bounce.py
+++ b/flanker/mime/bounce.py
@@ -1,78 +1,80 @@
 from collections import deque
 from contextlib import closing
 
+import attr
 import regex as re
 import six
+from attr.validators import instance_of
 from six.moves import range
 
 from flanker.mime.message.headers import MimeHeaders
 from flanker.mime.message.headers.parsing import parse_stream
 
 
+_HEADERS = ('Action',
+            'Content-Description',
+            'Diagnostic-Code',
+            'Final-Recipient',
+            'Received',
+            'Remote-Mta',
+            'Reporting-Mta',
+            'Status')
+
+_RE_STATUS = re.compile(r'\d\.\d+\.\d+', re.IGNORECASE)
+
+
+@attr.s(frozen=True)
+class Result(object):
+    score = attr.ib(validator=instance_of(float))
+    status = attr.ib(validator=instance_of(six.text_type))
+    diagnostic_code = attr.ib(validator=instance_of(six.text_type))
+    notification = attr.ib(validator=instance_of(six.text_type))
+
+    def is_bounce(self, probability=0.3):
+        return self.score > probability
+
+
 def detect(message):
-    headers = collect(message)
-    return Result(
-        score=len(headers) / float(len(HEADERS)),
-        status=get_status(headers),
-        notification=get_notification(message),
-        diagnostic_code=headers.get('Diagnostic-Code'))
+    headers = _collect_headers(message)
+    return Result(score=len(headers) / float(len(_HEADERS)),
+                  status=_get_status(headers),
+                  diagnostic_code=headers.get('Diagnostic-Code', u''),
+                  notification=_get_notification(message))
 
 
-def collect(message):
+def _collect_headers(message):
     collected = deque()
     for p in message.walk(with_self=True):
-        for h in HEADERS:
+        for h in _HEADERS:
             if h in p.headers:
                 collected.append((h, p.headers[h]))
         if p.content_type.is_delivery_status():
-            collected += collect_from_status(p.body)
+            collected += _collect_headers_from_status(p.body)
+
     return MimeHeaders(collected)
 
 
-def collect_from_status(body):
+def _collect_headers_from_status(body):
     out = deque()
     with closing(six.StringIO(body)) as stream:
         for i in range(3):
             out += parse_stream(stream)
+
     return out
 
 
-def get_status(headers):
+def _get_status(headers):
     for v in headers.getall('Status'):
-        if RE_STATUS.match(v.strip()):
+        if _RE_STATUS.match(v.strip()):
             return v
 
+    return u''
 
-def get_notification(message):
+
+def _get_notification(message):
     for part in message.walk():
         content_desc = part.headers.get('Content-Description', '').lower()
         if content_desc == 'notification':
             return part.body
 
-    return None
-
-
-HEADERS = ('Action',
-           'Content-Description',
-           'Diagnostic-Code',
-           'Final-Recipient',
-           'Received',
-           'Remote-Mta',
-           'Reporting-Mta',
-           'Status')
-
-RE_STATUS = re.compile(r'\d\.\d+\.\d+', re.IGNORECASE)
-
-
-class Result(object):
-    def __init__(self, score, status, notification, diagnostic_code):
-        self.score = score
-        self.status = status
-        self.notification = notification
-        self.diagnostic_code = diagnostic_code
-
-    def __repr__(self):
-        return (u'bounce.Result(status={}, score={}, notification={},'
-                u' diag_code={})'.format(self.status, self.score,
-                                         self.notification,
-                                         self.diagnostic_code))
+    return u''

--- a/flanker/mime/bounce.py
+++ b/flanker/mime/bounce.py
@@ -1,9 +1,12 @@
-import regex as re
 from collections import deque
 from contextlib import closing
-from cStringIO import StringIO
-from flanker.mime.message.headers.parsing import parse_stream
+
+import regex as re
+import six
+from six.moves import range
+
 from flanker.mime.message.headers import MimeHeaders
+from flanker.mime.message.headers.parsing import parse_stream
 
 
 def detect(message):
@@ -28,8 +31,8 @@ def collect(message):
 
 def collect_from_status(body):
     out = deque()
-    with closing(StringIO(body)) as stream:
-        for i in xrange(3):
+    with closing(six.StringIO(body)) as stream:
+        for i in range(3):
             out += parse_stream(stream)
     return out
 
@@ -42,9 +45,11 @@ def get_status(headers):
 
 def get_notification(message):
     for part in message.walk():
-        if part.headers.get('Content-Description',
-                            '').lower() == 'notification':
+        content_desc = part.headers.get('Content-Description', '').lower()
+        if content_desc == 'notification':
             return part.body
+
+    return None
 
 
 HEADERS = ('Action',

--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -1,9 +1,11 @@
+import six
+
 from flanker.mime.message.utils import to_unicode
 
 
 def convert_to_unicode(charset, value):
     #in case of unicode we have nothing to do
-    if isinstance(value, unicode):
+    if isinstance(value, six.text_type):
         return value
 
     charset = _translate_charset(charset)

--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -1,34 +1,38 @@
+import codecs
+
 import six
 
 from flanker.mime.message.utils import to_unicode
 
+_ALIASES = {
+    'sjis': 'shift_jis',
+    'windows-874': 'cp874',
+    'koi8-r': 'koi8_r'
+}
+
 
 def convert_to_unicode(charset, value):
-    #in case of unicode we have nothing to do
     if isinstance(value, six.text_type):
-        return value
+        if six.PY2:
+            return value
 
-    charset = _translate_charset(charset)
-    return to_unicode(value, charset=charset)
+        value = value.encode('ascii')
+
+    charset = _ensure_charset(charset)
+    value = to_unicode(value, charset)
+    return value
 
 
-def _translate_charset(charset):
-    """Translates crappy charset into Python analogue (if supported).
+def _ensure_charset(charset):
+    charset = charset.lower()
+    try:
+        codecs.lookup(charset)
+        return charset
+    except LookupError:
+        pass
 
-    Otherwise returns unmodified.
-    """
-    # ev: (ticket #2819)
-    if "sjis" in charset.lower():
-        return 'shift_jis'
+    charset = _ALIASES.get(charset)
+    if charset:
+        return charset
 
-    # cp874 looks to be an alias for windows-874
-    if "windows-874" == charset.lower():
-        return "cp874"
-
-    if 'koi8-r' in charset.lower():
-        return 'koi8_r'
-
-    if 'utf-8' in charset.lower() or charset.lower() == 'x-unknown':
-        return 'utf-8'
-
-    return charset
+    return 'utf-8'

--- a/flanker/mime/message/errors.py
+++ b/flanker/mime/message/errors.py
@@ -6,11 +6,11 @@ class DecodingError(MimeError):
     """Thrown when there is an encoding error."""
 
     def __str__(self):
-        return self.message[:256]
+        return MimeError.__str__(self)[:256]
 
 
 class EncodingError(MimeError):
     """Thrown when there is an decoding error."""
 
     def __str__(self):
-        return self.message[:256]
+        return MimeError.__str__(self)[:256]

--- a/flanker/mime/message/fallback/part.py
+++ b/flanker/mime/message/fallback/part.py
@@ -1,5 +1,7 @@
 import logging
 import email
+
+import six
 from webob.multidict import MultiDict
 from flanker.mime.message.charsets import convert_to_unicode
 from flanker.mime.message.headers.headers import remove_newlines, MimeHeaders
@@ -159,12 +161,13 @@ class FallbackHeaders(MimeHeaders):
 def _try_decode(key, value):
     if isinstance(value, (tuple, list)):
         return value
-    elif isinstance(value, str):
+    elif isinstance(value, six.binary_type):
         try:
             return headers.parse_header_value(key, value)
         except Exception:
-            return unicode(value, 'utf-8', 'ignore')
-    elif isinstance(value, unicode):
+            return value.decode('utf-8', 'ignore')
+
+    elif isinstance(value, six.text_type):
         return value
     else:
         return ""

--- a/flanker/mime/message/headers/encodedword.py
+++ b/flanker/mime/message/headers/encodedword.py
@@ -1,11 +1,11 @@
 # coding:utf-8
-import logging
-import regex as re
-
-import email.quoprimime
 import email.base64mime
-
+import email.quoprimime
+import logging
 from base64 import b64encode
+
+import regex as re
+import six
 
 from flanker.mime.message import charsets, errors
 
@@ -22,7 +22,7 @@ def unfold(value):
     treated in its unfolded form for further syntactic and semantic
     evaluation.
     """
-    return re.sub(foldingWhiteSpace, r"\2", value)
+    return re.sub(foldingWhiteSpace, r'\2', value)
 
 
 def decode(header):
@@ -43,7 +43,7 @@ def mime_to_unicode(header):
         u"Hello"
     """
     # Only string header values need to be converted.
-    if not isinstance(header, basestring):
+    if not isinstance(header, six.string_types):
         return header
 
     try:
@@ -75,7 +75,7 @@ def mime_to_unicode(header):
     except Exception:
         try:
             logged_header = header
-            if isinstance(logged_header, unicode):
+            if isinstance(logged_header, six.text_type):
                 logged_header = logged_header.encode('utf-8')
                 # encode header as utf-8 so all characters can be base64 encoded
             logged_header = b64encode(logged_header)

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -1,21 +1,23 @@
 import email.message
-import flanker.addresslib.address
 import logging
-
 from collections import deque
 from email.header import Header
+
+import six
+
+import flanker.addresslib.address
 from flanker.mime.message.headers import parametrized
 from flanker.mime.message.utils import to_utf8
 
-log = logging.getLogger(__name__)
+_log = logging.getLogger(__name__)
 
 # max length for a header line is 80 chars
 # max recursion depth is 1000
 # 80 * 1000 for header is too much for the system
 # so we allow just 100 lines for header
-MAX_HEADER_LENGTH = 8000
+_MAX_HEADER_LENGTH = 8000
 
-ADDRESS_HEADERS = ('From', 'To', 'Delivered-To', 'Cc', 'Bcc', 'Reply-To')
+_ADDRESS_HEADERS = ('From', 'To', 'Delivered-To', 'Cc', 'Bcc', 'Reply-To')
 
 
 def to_mime(key, value):
@@ -24,39 +26,39 @@ def to_mime(key, value):
 
     if type(value) == list:
         return "; ".join(encode(key, v) for v in value)
-    else:
-        return encode(key, value)
+
+    return encode(key, value)
 
 
 def encode(name, value):
     try:
         if parametrized.is_parametrized(name, value):
             value, params = value
-            return encode_parametrized(name, value, params)
-        else:
-            return encode_unstructured(name, value)
+            return _encode_parametrized(name, value, params)
+
+        return _encode_unstructured(name, value)
     except Exception:
-        log.exception("Failed to encode %s %s" % (name, value))
+        _log.exception("Failed to encode %s %s" % (name, value))
         raise
 
 
-def encode_unstructured(name, value):
-    if len(value) > MAX_HEADER_LENGTH:
+def _encode_unstructured(name, value):
+    if len(value) > _MAX_HEADER_LENGTH:
         return to_utf8(value)
     try:
         return Header(
             value.encode("ascii"), "ascii",
             header_name=name).encode(splitchars=' ;,')
     except (UnicodeEncodeError, UnicodeDecodeError):
-        if is_address_header(name, value):
-            return encode_address_header(name, value)
-        else:
-            return Header(
-                to_utf8(value), "utf-8",
-                header_name=name).encode(splitchars=' ;,')
+        if _is_address_header(name, value):
+            return _encode_address_header(name, value)
+
+        return Header(
+            to_utf8(value), "utf-8",
+            header_name=name).encode(splitchars=' ;,')
 
 
-def encode_address_header(name, value):
+def _encode_address_header(name, value):
     out = deque()
     for addr in flanker.addresslib.address.parse_list(value):
         if addr.requires_non_ascii():
@@ -66,17 +68,19 @@ def encode_address_header(name, value):
     return '; '.join(out)
 
 
-def encode_parametrized(key, value, params):
+def _encode_parametrized(key, value, params):
     if params:
-        params = [encode_param(key, n, v) for n, v in params.iteritems()]
+        params = [_encode_param(key, n, v) for n, v in six.iteritems(params)]
         return value + "; " + ("; ".join(params))
-    else:
-        return value
+
+    return value
 
 
-def encode_param(key, name, value):
+def _encode_param(key, name, value):
     try:
-        value = value.encode("ascii")
+        if six.PY2:
+            value = value.encode('ascii')
+
         return email.message._formatparam(name, value)
     except Exception:
         value = Header(value.encode("utf-8"), "utf-8",  header_name=key).encode(splitchars=' ;,')
@@ -93,5 +97,5 @@ def encode_string(name, value, maxlinelen=None):
     return header.encode(splitchars=' ;,')
 
 
-def is_address_header(key, val):
-    return key in ADDRESS_HEADERS and '@' in val
+def _is_address_header(key, val):
+    return key in _ADDRESS_HEADERS and '@' in val

--- a/flanker/mime/message/headers/headers.py
+++ b/flanker/mime/message/headers/headers.py
@@ -1,3 +1,4 @@
+import six
 from webob.multidict import MultiDict
 
 from flanker.mime.message.headers import encodedword
@@ -158,7 +159,7 @@ class MimeHeaders(object):
 def remove_newlines(value):
     if not value:
         return ''
-    elif isinstance(value, (str, unicode)):
+    elif isinstance(value, six.string_types):
         return value.replace('\r', '').replace('\n', '')
     else:
         return value

--- a/flanker/mime/message/headers/headers.py
+++ b/flanker/mime/message/headers/headers.py
@@ -150,7 +150,7 @@ class MimeHeaders(object):
                 break
             i += 1
             try:
-                h = h.encode('ascii')
+                h.encode('ascii')
             except UnicodeDecodeError:
                 raise EncodingError("Non-ascii header name")
             stream.write("{0}: {1}\r\n".format(h, to_mime(h, v)))

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -30,7 +30,7 @@ def parse_header(header):
     """
     name, val = _split_header(header)
     if not is_pure_ascii(name):
-        raise DecodingError("Non-ascii header name")
+        raise DecodingError('Non-ascii header name')
 
     return name, parse_header_value(name, encodedword.unfold(val))
 
@@ -38,7 +38,7 @@ def parse_header(header):
 def parse_header_value(name, val):
     if not is_pure_ascii(val):
         if parametrized.is_parametrized(name, val):
-            raise DecodingError("Unsupported value in content- header")
+            raise DecodingError('Unsupported value in content- header')
 
         return to_unicode(val)
 
@@ -62,7 +62,7 @@ def _read_header_lines(fp):
     lines = deque()
     for line in fp:
         if len(line) > _MAX_LINE_LENGTH:
-            raise DecodingError("Line is too long: %d" % len(line))
+            raise DecodingError('Line is too long: %d' % len(line))
 
         if is_empty(line):
             break

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -7,18 +7,20 @@ from flanker.mime.message.errors import DecodingError
 from flanker.mime.message.utils import to_unicode
 from flanker.utils import is_pure_ascii
 
-MAX_LINE_LENGTH = 10000
+_RE_HEADER = regex.compile(r'^(From |[\041-\071\073-\176]+:|[\t ])')
+_MAX_LINE_LENGTH = 10000
 
 
-def normalize(header):
-    return string.capwords(header.lower(), '-')
+def normalize(header_name):
+    return string.capwords(header_name.lower(), '-')
 
 
 def parse_stream(stream):
     """Reads the incoming stream and returns list of tuples"""
     out = deque()
-    for header in unfold(split(stream)):
+    for header in _unfold_header_lines(_read_header_lines(stream)):
         out.append(parse_header(header))
+
     return out
 
 
@@ -26,9 +28,10 @@ def parse_header(header):
     """ Accepts a raw header with name, colons and newlines
     and returns it's parsed value
     """
-    name, val = split2(header)
+    name, val = _split_header(header)
     if not is_pure_ascii(name):
         raise DecodingError("Non-ascii header name")
+
     return name, parse_header_value(name, encodedword.unfold(val))
 
 
@@ -36,33 +39,30 @@ def parse_header_value(name, val):
     if not is_pure_ascii(val):
         if parametrized.is_parametrized(name, val):
             raise DecodingError("Unsupported value in content- header")
+
         return to_unicode(val)
-    else:
-        if parametrized.is_parametrized(name, val):
-            val, params = parametrized.decode(val)
-            if name == 'Content-Type':
-                main, sub = parametrized.fix_content_type(val)
-                return ContentType(main, sub, params)
-            else:
-                return WithParams(val, params)
-        else:
-            return val
+
+    if parametrized.is_parametrized(name, val):
+        val, params = parametrized.decode(val)
+        if name == 'Content-Type':
+            main, sub = parametrized.fix_content_type(val)
+            return ContentType(main, sub, params)
+
+        return WithParams(val, params)
+
+    return val
 
 
 def is_empty(line):
     return line in ('\r\n', '\r', '\n')
 
 
-RE_HEADER = regex.compile(r'^(From |[\041-\071\073-\176]+:|[\t ])')
-
-
-def split(fp):
+def _read_header_lines(fp):
     """Read lines with headers until the start of body"""
     lines = deque()
     for line in fp:
-        if len(line) > MAX_LINE_LENGTH:
-            raise DecodingError(
-                "Line is too long: {0}".format(len(line)))
+        if len(line) > _MAX_LINE_LENGTH:
+            raise DecodingError("Line is too long: %d" % len(line))
 
         if is_empty(line):
             break
@@ -70,7 +70,7 @@ def split(fp):
         # tricky case if it's not a header and not an empty line
         # ususally means that user forgot to separate the body and newlines
         # so "unread" this line here, what means to treat it like a body
-        if not RE_HEADER.match(line):
+        if not _RE_HEADER.match(line):
             fp.seek(fp.tell() - len(line))
             break
 
@@ -79,47 +79,51 @@ def split(fp):
     return lines
 
 
-def unfold(lines):
+def _unfold_header_lines(lines):
     headers = deque()
-
     for line in lines:
         # ignore unix from
         if line.startswith('From '):
             continue
+
         # this is continuation
-        elif line[0] in ' \t':
-            extend(headers, line)
-        else:
-            headers.append(line)
+        if line[0] in ' \t':
+            _extend_last_header(headers, line)
+            continue
+
+        headers.append(line)
 
     new_headers = deque()
     for h in headers:
         if isinstance(h, deque):
             new_headers.append(''.join(h).rstrip('\r\n'))
-        else:
-            new_headers.append(h.rstrip('\r\n'))
+            continue
+
+        new_headers.append(h.rstrip('\r\n'))
 
     return new_headers
 
 
-def extend(headers, line):
-    try:
-        header = headers.pop()
-    except IndexError:
-        # this means that we got invalid header
-        # ignore it
+def _extend_last_header(headers, line):
+    # Ignore continuation header lines at the top of a part.
+    if len(headers) == 0:
         return
 
+    header = headers.pop()
+
+    # If the latest header is already multiline then extend it.
     if isinstance(header, deque):
         header.append(line)
         headers.append(header)
-    else:
-        headers.append(deque((header, line)))
+        return
+
+    # Convert the latest header to a multiline one.
+    headers.append(deque((header, line)))
 
 
-def split2(header):
+def _split_header(header):
     pair = header.split(':', 1)
     if len(pair) == 2:
         return normalize(pair[0].rstrip()), pair[1].lstrip()
-    else:
-        return (None, None)
+
+    return None, None

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -84,7 +84,7 @@ def unfold(lines):
 
     for line in lines:
         # ignore unix from
-        if line.startswith("From "):
+        if line.startswith('From '):
             continue
         # this is continuation
         elif line[0] in ' \t':
@@ -95,9 +95,9 @@ def unfold(lines):
     new_headers = deque()
     for h in headers:
         if isinstance(h, deque):
-            new_headers.append("".join(h).rstrip("\r\n"))
+            new_headers.append(''.join(h).rstrip('\r\n'))
         else:
-            new_headers.append(h.rstrip("\r\n"))
+            new_headers.append(h.rstrip('\r\n'))
 
     return new_headers
 
@@ -118,7 +118,7 @@ def extend(headers, line):
 
 
 def split2(header):
-    pair = header.split(":", 1)
+    pair = header.split(':', 1)
     if len(pair) == 2:
         return normalize(pair[0].rstrip()), pair[1].lstrip()
     else:

--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -2,10 +2,12 @@
 provide some convenience access methods
 """
 
-import regex as re
-import flanker.addresslib.address
-
 from email.utils import make_msgid
+
+import regex as re
+import six
+
+import flanker.addresslib.address
 
 
 class WithParams(tuple):
@@ -119,7 +121,7 @@ class ContentType(tuple):
                 and self.params == other.params
         elif isinstance(other, tuple):
             return tuple.__eq__(self, other)
-        elif isinstance(other, (unicode, str)):
+        elif isinstance(other, six.string_types):
             return str(self) == other
         else:
             return False
@@ -155,7 +157,7 @@ class MessageId(str):
 
     @classmethod
     def from_string(cls, string):
-        if not isinstance(string, (str, unicode)):
+        if not isinstance(string, six.string_types):
             return None
         for message_id in cls.scan(string):
             return message_id
@@ -181,11 +183,11 @@ class MessageId(str):
                 yield cls(message_id)
 
 
-class Subject(unicode):
+class Subject(six.text_type):
     RE_RE = re.compile("((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
 
     def __new__(cls, *args, **kw):
-        return unicode.__new__(cls, *args, **kw)
+        return six.text_type.__new__(cls, *args, **kw)
 
     def strip_replies(self):
         return self.RE_RE.sub('', self)

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -137,8 +137,8 @@ def _guess_type(filename):
 
 
 class Body(object):
-    def __init__(
-        self, content_type, body, charset=None, disposition=None, filename=None, trust_ctype=False):
+    def __init__(self, content_type, body, charset=None, disposition=None,
+                 filename=None, trust_ctype=False):
         self.headers = headers.MimeHeaders()
         self.body = body
         self.disposition = disposition or ('attachment' if filename else None)
@@ -157,7 +157,8 @@ class Body(object):
                 charset = "utf-8"
 
             # it should be stored as unicode. period
-            self.body = charsets.convert_to_unicode(charset, body)
+            if isinstance(body, six.binary_type):
+                self.body = charsets.convert_to_unicode(charset, body)
 
             # let's be simple when possible
             if charset != 'ascii' and is_pure_ascii(body):

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -367,16 +367,7 @@ class RichPartMixin(object):
     @property
     def bounce(self):
         """
-        If the message is NOT bounce, then `None` is returned. Otherwise
-        it returns a bounce object that provides the values:
-          * score - a value between 0 and 1, where 0 means that the message is
-                    definitely not a bounce, and 1 means that is definitely a
-                    bounce;
-          * status -  delivery status;
-          * notification - human readable description;
-          * diagnostic_code - smtp diagnostic codes;
-
-        Can raise MimeError in case if MIME is screwed.
+        Deprecated: use bounce.detect(message).
         """
         if not self._bounce:
             self._bounce = bounce.detect(self)
@@ -384,10 +375,9 @@ class RichPartMixin(object):
 
     def is_bounce(self, probability=0.3):
         """
-        Determines whether the message is a bounce message based on
-        given probability. 0.3 is a good conservative base.
+        Deprecated: use bounce.detect(message).
         """
-        return self.bounce.score > probability
+        return self.bounce.is_bounce(probability)
 
     def __str__(self):
         return "({0})".format(self.content_type)

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -5,20 +5,19 @@ import logging
 import mimetypes
 import quopri
 from contextlib import closing
-from cStringIO import StringIO
-
-from os import path
 from email.mime import audio
+from os import path
+
+import six
 
 from flanker import metrics
 from flanker.mime import bounce
 from flanker.mime.message import headers, charsets
+from flanker.mime.message.errors import EncodingError, DecodingError
 from flanker.mime.message.headers import (WithParams, ContentType, MessageId,
                                           Subject)
 from flanker.mime.message.headers.parametrized import fix_content_type
-from flanker.mime.message.errors import EncodingError, DecodingError
 from flanker.utils import is_pure_ascii
-
 
 log = logging.getLogger(__name__)
 
@@ -480,11 +479,11 @@ class MimePart(RichPartMixin):
         # we submit the original string,
         # no copying, no alternation, yeah!
         if self.is_root() and not self.was_changed(ignore_prepends=True):
-            with closing(StringIO()) as out:
+            with closing(six.StringIO()) as out:
                 self._container._stream_prepended_headers(out)
                 return out.getvalue() + self._container.string
         else:
-            with closing(StringIO()) as out:
+            with closing(six.StringIO()) as out:
                 self.to_stream(out)
                 return out.getvalue()
 

--- a/flanker/mime/message/scanner.py
+++ b/flanker/mime/message/scanner.py
@@ -399,6 +399,9 @@ def tokenize(string):
     """
     Scans the entire message to find all Content-Types and boundaries.
     """
+    if six.PY3 and isinstance(string, six.binary_type):
+        string = string.decode('utf-8')
+
     tokens = deque()
     for m in _RE_TOKENIZER.finditer(string):
         if m.group(_CTYPE):

--- a/flanker/mime/message/scanner.py
+++ b/flanker/mime/message/scanner.py
@@ -1,11 +1,12 @@
-import regex as re
 from collections import deque
-from cStringIO import StringIO
-import sys
+from logging import getLogger
+
+import regex as re
+import six
+
+from flanker.mime.message.errors import DecodingError
 from flanker.mime.message.headers import parsing, is_empty, ContentType
 from flanker.mime.message.part import MimePart, Stream
-from flanker.mime.message.errors import DecodingError
-from logging import getLogger
 
 log = getLogger(__name__)
 
@@ -14,8 +15,12 @@ def scan(string):
     """Scanner that uses 1 pass to scan the entire message and
     build a message tree"""
 
-    if not isinstance(string, str):
-        raise DecodingError("Scanner works with byte strings only")
+    if six.PY2:
+        if not isinstance(string, six.binary_type):
+            raise DecodingError('Scanner works with binary only')
+    else:
+        if isinstance(string, six.binary_type):
+            string = string.decode('utf-8')
 
     tokens = tokenize(string)
     if not tokens:
@@ -24,8 +29,8 @@ def scan(string):
         return traverse(Start(), TokensIterator(tokens, string))
     except DecodingError:
         raise
-    except Exception:
-        raise DecodingError("Malformed MIME message"), None, sys.exc_info()[2]
+    except Exception as cause:
+        raise six.raise_from(DecodingError("Malformed MIME message"), cause)
 
 
 def traverse(pointer, iterator, parent=None, allow_bad_mime=False):
@@ -245,7 +250,7 @@ class TokensIterator(object):
         self.position = -1
         self.tokens = tokens
         self.string = string
-        self.stream = StringIO(string)
+        self.stream = six.StringIO(string)
         self.opcount = 0
 
     def next(self):
@@ -399,7 +404,7 @@ def tokenize(string):
         if m.group(_CTYPE):
             name, token = parsing.parse_header(m.group(_CTYPE))
         elif m.group(_BOUNDARY):
-            token = Boundary(m.group(_BOUNDARY).strip("\t\r\n"),
+            token = Boundary(m.group(_BOUNDARY).strip('\t\r\n'),
                              _grab_newline(m.start(), string, -1),
                              _grab_newline(m.end(), string, 1))
         else:
@@ -486,7 +491,7 @@ def _filter_false_tokens(tokens):
             continue
 
         else:
-            raise DecodingError("Unknown token")
+            raise DecodingError('Unknown token')
 
         filtered.append(token)
 
@@ -494,7 +499,7 @@ def _filter_false_tokens(tokens):
 
 
 def _strip_endings(value):
-    if value.endswith("--"):
+    if value.endswith('--'):
         return value[:-2]
     else:
         return value

--- a/flanker/mime/message/threading.py
+++ b/flanker/mime/message/threading.py
@@ -3,6 +3,8 @@ Implements message threading
 """
 from email.utils import make_msgid
 
+import six
+
 
 def build_thread(messages):
     """
@@ -24,7 +26,7 @@ def build_table(messages):
 
 def build_root_set(table):
     root = Container()
-    for container in table.itervalues():
+    for container in six.itervalues(table):
         if not container.parent:
             root.add_child(container)
     return root
@@ -200,5 +202,3 @@ class Wrapper(object):
         self.message = message
         self.message_id = message.message_id or make_msgid()
         self.references = message.references
-        #self.subject = message.subject
-        #self.clean_subject = message.clean_subject

--- a/flanker/mime/message/utils.py
+++ b/flanker/mime/message/utils.py
@@ -1,14 +1,16 @@
-from cStringIO import StringIO
 from contextlib import closing
 from email.generator import Generator
-from flanker.mime.message import errors
+
 import cchardet
 import chardet
+import six
+
+from flanker.mime.message import errors
 
 
 def python_message_to_string(msg):
     """Converts python message to string in a proper way"""
-    with closing(StringIO()) as fp:
+    with closing(six.StringIO()) as fp:
         g = Generator(fp, mangle_from_=False)
         g.flatten(msg, unixfrom=False)
         return fp.getvalue()
@@ -46,7 +48,7 @@ def _guess_and_convert(value):
 
 
 def _make_unicode(value, charset=None):
-    if isinstance(value, unicode):
+    if isinstance(value, six.text_type):
         return value
 
     charset = charset or "utf-8"

--- a/flanker/utils.py
+++ b/flanker/utils.py
@@ -3,12 +3,13 @@
 Utility functions and classes used by flanker.
 """
 import re
-
 from functools import wraps
+
+import six
 
 
 def is_pure_ascii(value):
-    '''
+    """
     Determines whether the given string is a pure ascii
     string
     >>> utils.is_pure_ascii(u"Cаша")
@@ -17,18 +18,28 @@ def is_pure_ascii(value):
         True
     >>> utils.is_pure_ascii("Alice")
         True
-    '''
+    """
 
     if value is None:
         return False
-    if not isinstance(value, basestring):
-        return False
 
-    try:
-        value.encode("ascii")
-    except (UnicodeEncodeError, UnicodeDecodeError):
-        return False
-    return True
+    if isinstance(value, six.binary_type):
+        try:
+            value.decode('ascii')
+        except UnicodeDecodeError:
+            return False
+
+        return True
+
+    if isinstance(value, six.text_type):
+        try:
+            value.encode('ascii')
+        except UnicodeEncodeError:
+            return False
+
+        return True
+
+    return False
 
 
 def cleanup_display_name(name):
@@ -68,5 +79,7 @@ def metrics_wrapper():
 
 
 # allows, \t\n\v\f\r (0x09-0x0d)
-CONTROL_CHARS = ''.join(map(unichr, range(0, 9) + range(14, 32) + range(127, 160)))
+CONTROL_CHARS = ''.join([six.unichr(c) for c in range(0, 9)] +
+                        [six.unichr(c) for c in range(14, 32)] +
+                        [six.unichr(c) for c in range(127, 160)])
 CONTROL_CHAR_RE = re.compile('[%s]' % re.escape(CONTROL_CHARS))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='flanker',
-      version='0.7.4',
+      version='0.8.0',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='flanker',
           'mock'
       ],
       install_requires=[
+          'attrs',
           'chardet>=1.0.1',
           'cchardet>=0.3.5',
           'cryptography>=0.5',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='flanker',
           'idna>=2.5',
           'ply>=3.10',
           'regex>=0.1.20110315',
+          'six',
           'WebOb>=0.9.8'],
       extras_require={
           'validator': [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,6 +28,7 @@ def read_fixture_bytes(path):
 
 # mime fixture files
 BOUNCE = read_fixture_bytes('messages/bounce/zed.eml')
+BOUNCE_OFFICE365 = read_fixture_bytes('messages/bounce/office365.eml')
 MAILBOX_FULL = read_fixture_bytes('messages/bounce/mailbox-full.eml')
 NDN = read_fixture_bytes('messages/bounce/delayed.eml')
 NDN_BROKEN = read_fixture_bytes('messages/bounce/delayed-broken.eml')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,106 +6,100 @@ import codecs
 
 
 def fixtures_path():
-    return join(abspath(dirname(__file__)), "fixtures")
+    return join(abspath(dirname(__file__)), 'fixtures')
+
 
 def fixture_file(name):
     return join(fixtures_path(), name)
 
+
 def skip_if_asked():
     from nose import SkipTest
     import sys
-    if "--no-skip" not in sys.argv:
+    if '--no-skip' not in sys.argv:
         raise SkipTest()
 
 
+def read_fixture_bytes(path):
+    absolute_path = join(abspath(dirname(__file__)), 'fixtures', path)
+    with open(absolute_path, 'rb') as f:
+        return f.read()
+
+
 # mime fixture files
-BOUNCE = open(fixture_file("messages/bounce/zed.eml")).read()
-MAILBOX_FULL = open(fixture_file("messages/bounce/mailbox-full.eml")).read()
-NDN = open(fixture_file("messages/bounce/delayed.eml")).read()
-NDN_BROKEN = open(fixture_file("messages/bounce/delayed-broken.eml")).read()
+BOUNCE = read_fixture_bytes('messages/bounce/zed.eml')
+MAILBOX_FULL = read_fixture_bytes('messages/bounce/mailbox-full.eml')
+NDN = read_fixture_bytes('messages/bounce/delayed.eml')
+NDN_BROKEN = read_fixture_bytes('messages/bounce/delayed-broken.eml')
 
-SIGNED_FILE = open(fixture_file("messages/signed.eml"))
-SIGNED = open(fixture_file("messages/signed.eml")).read()
-LONG_LINKS = open(fixture_file("messages/long-links.eml")).read()
-MULTI_RECEIVED_HEADERS = open(
-    fixture_file("messages/multi-received-headers.eml")).read()
-MAILGUN_PNG = open(fixture_file("messages/attachments/mailgun.png")).read()
-MAILGUN_WAV = open(
-    fixture_file("messages/attachments/mailgun-rocks.wav")).read()
+SIGNED = read_fixture_bytes('messages/signed.eml')
+LONG_LINKS = read_fixture_bytes('messages/long-links.eml')
+MULTI_RECEIVED_HEADERS = read_fixture_bytes(
+    'messages/multi-received-headers.eml')
+MAILGUN_PNG = read_fixture_bytes('messages/attachments/mailgun.png')
+MAILGUN_WAV = read_fixture_bytes('messages/attachments/mailgun-rocks.wav')
 
-TORTURE = open(fixture_file("messages/torture.eml")).read()
-TORTURE_PART = open(fixture_file("messages/torture-part.eml")).read()
-BILINGUAL = open(fixture_file("messages/bilingual-simple.eml")).read()
-RELATIVE = open(fixture_file("messages/relative.eml")).read()
-IPHONE = open(fixture_file("messages/iphone.eml")).read()
+TORTURE = read_fixture_bytes('messages/torture.eml')
+TORTURE_PART = read_fixture_bytes('messages/torture-part.eml')
+BILINGUAL = read_fixture_bytes('messages/bilingual-simple.eml')
+RELATIVE = read_fixture_bytes('messages/relative.eml')
+IPHONE = read_fixture_bytes('messages/iphone.eml')
 
-MULTIPART = open(fixture_file("messages/multipart.eml")).read()
-FROM_ENCODING = open(fixture_file("messages/from-encoding.eml")).read()
-NO_CTYPE = open(fixture_file("messages/no-ctype.eml")).read()
-APACHE_MIME_MESSAGE_NEWS = open(fixture_file("messages/apache-message-news-mime.eml")).read()
-ENCLOSED = open(fixture_file("messages/enclosed.eml")).read()
-ENCLOSED_BROKEN_BOUNDARY = open(
-    fixture_file("messages/enclosed-broken.eml")).read()
-ENCLOSED_ENDLESS = open(
-    fixture_file("messages/enclosed-endless.eml")).read()
-ENCLOSED_BROKEN_BODY = open(
-    fixture_file("messages/enclosed-broken-body.eml")).read()
-ENCLOSED_BROKEN_ENCODING = open(
-    fixture_file("messages/enclosed-bad-encoding.eml")).read()
-FALSE_MULTIPART = open(
-    fixture_file("messages/false-multipart.eml")).read()
-ENCODED_HEADER = open(
-    fixture_file("messages/encoded-header.eml")).read()
-MESSAGE_EXTERNAL_BODY= open(
-    fixture_file("messages/message-external-body.eml")).read()
-EIGHT_BIT = open(fixture_file("messages/8bitmime.eml")).read()
-BIG = open(fixture_file("messages/big.eml")).read()
-RUSSIAN_ATTACH_YAHOO = open(
-    fixture_file("messages/russian-attachment-yahoo.eml")).read()
-QUOTED_PRINTABLE = open(
-    fixture_file("messages/quoted-printable.eml")).read()
-TEXT_ONLY = open(fixture_file("messages/text-only.eml")).read()
-MAILGUN_PIC = open(fixture_file("messages/mailgun-pic.eml")).read()
-BZ2_ATTACHMENT  = open(fixture_file("messages/bz2-attachment.eml")).read()
-OUTLOOK_EXPRESS = open(fixture_file("messages/outlook-express.eml")).read()
+MULTIPART = read_fixture_bytes('messages/multipart.eml')
+FROM_ENCODING = read_fixture_bytes('messages/from-encoding.eml')
+NO_CTYPE = read_fixture_bytes('messages/no-ctype.eml')
+APACHE_MIME_MESSAGE_NEWS = read_fixture_bytes(
+    'messages/apache-message-news-mime.eml')
+ENCLOSED = read_fixture_bytes('messages/enclosed.eml')
+ENCLOSED_BROKEN_BOUNDARY = read_fixture_bytes('messages/enclosed-broken.eml')
+ENCLOSED_ENDLESS = read_fixture_bytes('messages/enclosed-endless.eml')
+ENCLOSED_BROKEN_BODY = read_fixture_bytes('messages/enclosed-broken-body.eml')
+ENCLOSED_BROKEN_ENCODING = read_fixture_bytes(
+    'messages/enclosed-bad-encoding.eml')
+FALSE_MULTIPART = read_fixture_bytes('messages/false-multipart.eml')
+ENCODED_HEADER = read_fixture_bytes('messages/encoded-header.eml')
+MESSAGE_EXTERNAL_BODY= read_fixture_bytes(
+    'messages/message-external-body.eml')
+EIGHT_BIT = read_fixture_bytes('messages/8bitmime.eml')
+BIG = read_fixture_bytes('messages/big.eml')
+RUSSIAN_ATTACH_YAHOO = read_fixture_bytes(
+    'messages/russian-attachment-yahoo.eml')
+QUOTED_PRINTABLE = read_fixture_bytes('messages/quoted-printable.eml')
+TEXT_ONLY = read_fixture_bytes('messages/text-only.eml')
+MAILGUN_PIC = read_fixture_bytes('messages/mailgun-pic.eml')
+BZ2_ATTACHMENT  = read_fixture_bytes('messages/bz2-attachment.eml')
+OUTLOOK_EXPRESS = read_fixture_bytes('messages/outlook-express.eml')
 
-AOL_FBL = open(fixture_file("messages/complaints/aol.eml")).read()
-YAHOO_FBL = open(fixture_file("messages/complaints/yahoo.eml")).read()
-NOTIFICATION = open(fixture_file("messages/bounce/no-mx.eml")).read()
-DASHED_BOUNDARIES = open(
-    fixture_file("messages/dashed-boundaries.eml")).read()
-WEIRD_BOUNCE = open(fixture_file("messages/bounce/gmail-no-dns.eml")).read()
-WEIRD_BOUNCE_2 = open(
-    fixture_file("messages/bounce/gmail-invalid-address.eml")).read()
+AOL_FBL = read_fixture_bytes('messages/complaints/aol.eml')
+YAHOO_FBL = read_fixture_bytes('messages/complaints/yahoo.eml')
+NOTIFICATION = read_fixture_bytes('messages/bounce/no-mx.eml')
+DASHED_BOUNDARIES = read_fixture_bytes('messages/dashed-boundaries.eml')
+WEIRD_BOUNCE = read_fixture_bytes('messages/bounce/gmail-no-dns.eml')
+WEIRD_BOUNCE_2 = read_fixture_bytes(
+    'messages/bounce/gmail-invalid-address.eml')
 
-WEIRD_BOUNCE_3 = open(
-    fixture_file("messages/bounce/broken-mime.eml")).read()
-MISSING_BOUNDARIES = open(
-    fixture_file("messages/missing-boundaries.eml")).read()
-MISSING_FINAL_BOUNDARY = open(
-    fixture_file("messages/missing-final-boundary.eml")).read()
-DISPOSITION_NOTIFICATION = open(
-    fixture_file("messages/disposition-notification.eml")).read()
-MAILFORMED_HEADERS = open(
-    fixture_file("messages/mailformed-headers.eml")).read()
+WEIRD_BOUNCE_3 = read_fixture_bytes('messages/bounce/broken-mime.eml')
+MISSING_BOUNDARIES = read_fixture_bytes('messages/missing-boundaries.eml')
+MISSING_FINAL_BOUNDARY = read_fixture_bytes(
+    'messages/missing-final-boundary.eml')
+DISPOSITION_NOTIFICATION = read_fixture_bytes(
+    'messages/disposition-notification.eml')
+MAILFORMED_HEADERS = read_fixture_bytes('messages/mailformed-headers.eml')
 
-SPAM_BROKEN_HEADERS = open(
-    fixture_file("messages/spam/broken-headers.eml")).read()
-SPAM_BROKEN_CTYPE = open(
-    fixture_file("messages/spam/broken-ctype.eml")).read()
-LONG_HEADER = open(
-    fixture_file("messages/long-header.eml")).read()
-ATTACHED_PDF = open(fixture_file("messages/attached-pdf.eml")).read()
-
-
+SPAM_BROKEN_HEADERS = read_fixture_bytes('messages/spam/broken-headers.eml')
+SPAM_BROKEN_CTYPE = read_fixture_bytes('messages/spam/broken-ctype.eml')
+LONG_HEADER = read_fixture_bytes('messages/long-header.eml')
+ATTACHED_PDF = read_fixture_bytes('messages/attached-pdf.eml')
 
 # addresslib fixture files
-MAILBOX_VALID_TESTS = open(fixture_file("mailbox_valid.txt")).read()
-MAILBOX_INVALID_TESTS = open(fixture_file("mailbox_invalid.txt")).read()
-ABRIDGED_LOCALPART_VALID_TESTS = open(fixture_file("abridged_localpart_valid.txt")).read()
-ABRIDGED_LOCALPART_INVALID_TESTS = open(fixture_file("abridged_localpart_invalid.txt")).read()
-URL_VALID_TESTS = codecs.open(fixture_file("url_valid.txt"), encoding='utf-8', mode='r').read()
-URL_INVALID_TESTS = codecs.open(fixture_file("url_invalid.txt"), encoding='utf-8', mode='r').read()
+MAILBOX_VALID_TESTS = read_fixture_bytes('mailbox_valid.txt')
+MAILBOX_INVALID_TESTS = read_fixture_bytes('mailbox_invalid.txt')
+ABRIDGED_LOCALPART_VALID_TESTS = read_fixture_bytes(
+    'abridged_localpart_valid.txt')
+ABRIDGED_LOCALPART_INVALID_TESTS = read_fixture_bytes(
+    'abridged_localpart_invalid.txt')
+URL_VALID_TESTS = read_fixture_bytes('url_valid.txt').decode('utf-8')
+URL_INVALID_TESTS = read_fixture_bytes('url_invalid.txt').decode('utf-8')
 
-DOMAIN_TYPO_VALID_TESTS = open(fixture_file("domain_typos_valid.txt")).read()
-DOMAIN_TYPO_INVALID_TESTS = open(fixture_file("domain_typos_invalid.txt")).read()
+DOMAIN_TYPO_VALID_TESTS = read_fixture_bytes('domain_typos_valid.txt')
+DOMAIN_TYPO_INVALID_TESTS = read_fixture_bytes('domain_typos_invalid.txt')

--- a/tests/fixtures/messages/bounce/office365.eml
+++ b/tests/fixtures/messages/bounce/office365.eml
@@ -1,0 +1,1131 @@
+X-Mailgun-Spam-Rules: DKIM_SIGNED, DKIM_VALID, HTML_MESSAGE, MIME_HTML_MOSTLY,
+ NORMAL_HTTP_TO_IP, RCVD_IN_DNSWL_NONE, SPF_HELO_PASS, URIBL_BLOCKED
+X-Mailgun-Dkim-Check-Result: Pass
+X-Mailgun-Spf: Pass
+X-Mailgun-Sscore: 0.0
+X-Mailgun-Sflag: No
+X-Mailgun-Incoming: Yes
+Received: from EUR01-HE1-obe.outbound.protection.outlook.com (mail-he1eur01hn0223.outbound.protection.outlook.com [104.47.0.223])
+ by mxa.mailgun.org with ESMTP id 59e09f1b.7f31e76958c8-api-01;
+ Fri, 13 Oct 2017 11:10:19 -0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=examplenorge.onmicrosoft.com; s=selector1-example-no;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version;
+ bh=yfKQqTOooDdyliev9ug3fBSp+NC30VUAr9xUChswGoA=;
+ b=WXYHRzffqy5frife0kpHVfaioykHNwOHg8VJBjAr3bhVDId7gsF+xhs/2Ksq+UuvxiDItaI2ui7UbXXzBgDkzj+ZC+W7PYG7+QLbfz4mCFAszQMWVGQPRd00eBbjO1iiAiYkDpqgkV56l16mWXXQBAxj+vbcUCOVQie+5xfNuUk=
+MIME-Version: 1.0
+From: <postmaster@example.no>
+To: <postmaster@ninomail.com>
+Date: Fri, 13 Oct 2017 11:10:16 +0000
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="22a54575-c842-43f3-83ea-721e8360fb4c"
+X-MS-Exchange-Message-Is-Ndr:
+Content-Language: en-US
+Message-ID: <2ab24bbc-78da-492a-9f68-438ddae558bb@DB5PR06MB1800.eurprd06.prod.outlook.com>
+In-Reply-To: <20171013111011.20866.254C2F3A4D7AA526@ninomail.com>
+References: <20171013111011.20866.254C2F3A4D7AA526@ninomail.com>
+Subject: Undeliverable: test_bounce 8
+Auto-Submitted: auto-replied
+X-MS-PublicTrafficType: Email
+X-MS-TrafficTypeDiagnostic: DB5PR06MB1800:
+X-MS-Office365-Filtering-Correlation-Id: 8f2b4ff8-a8f6-40e6-0fa5-08d5122afbe8
+X-Microsoft-Exchange-Diagnostics:
+	1;DB5PR06MB1800;25:dMcqypSP9k67Vv9AKu6Pato55s5v3lUXrpLyU8u4hWzTnwKnBRDff/vPF9U8fGfY5E1GRFiBEovEBfnyO0FbTBKJCtlKrhryFueZxIWnzEIrJ2ji9HrRdjdOUYxoO8+odX2du1LqIR3f7fG2uamJBr+HmzpOmO9pSq4YpYvcUq73N3zjW4FiNkfn2c1mmPjI3jcMXYUocSxkT+agiuYB5Tfqd1hYrk/1/eiP902SZMXhoudaQswkWQlyLmlpiSnIEbP9B4Wao5Qj5Nf12/M0cs9FR33dKZCOisj/XrrqMnrWSPqv+F25olMqNV24SvcO6sMQEMA+pY0dYcl9kyhKjbP/VA+nhjqSG/8UR91FY2s=;31:W9G1RkrlGHV5c7LbK0vfBCGvKc4BtpWyeLX3Rg/UIFkfyz+I9w13pUJ/4Aao0Jgt6WWHvGwbpLc/JMLWpII/CZto0A815LAwSSWIUJUZd5Cd7+W987Kz3shHoP7dVdT6ymUzGspCT9bqfvRClBZ3oO3SP0dl+Bup+YXdvGj4s+rUQoPRFbjtnVSshbxfAt2TOPbucMrsKxw3gWGk5NXMPWjmaQGwqyUS38IzI0W4C/I=
+X-Exchange-Antispam-Report-Test:
+	UriScan:(158342451672863)(156600954879566)(160011542660777)(189930954265078)(215449377671575)(266611908612381)(266651597892604)(277809949798613)(112002664235607)(136887953259498);
+X-Microsoft-Antispam-PRVS:
+	<DB5PR06MB1800B18B7647668245ECE8B1B8480@DB5PR06MB1800.eurprd06.prod.outlook.com>
+X-Exchange-Antispam-Report-CFA-Test:
+	BCL:0;PCL:0;RULEID:(100000700101)(100105000095)(100000701101)(100105300095)(100000702101)(100105100095)(102415395)(53401082)(6040450)(2401047)(5005006)(8121501046)(10201501046)(3002001)(93006095)(100000703101)(100105400095)(6041248)(201703131423075)(201702281528075)(201703061421075)(201703061750153)(20161123558100)(20161123562025)(20161123564025)(20161123555025)(20161123560025)(53402082)(6072148)(201708071742011)(100000704101)(100105200095)(100000705101)(100105500095);SRVR:DB5PR06MB1800;BCL:0;PCL:0;RULEID:(100000800101)(100110000095)(100000801101)(100110300095)(100000802101)(100110100095)(100000803101)(100110400095)(100000804101)(100110200095)(100000805101)(100110500095);SRVR:DB5PR06MB1800;
+X-Microsoft-Exchange-Diagnostics:
+	1;DB5PR06MB1800;4:/GAkPwE/Z8lSgDwBKM/VkYfWm3iU12GDBfzKJbpnmPnk/v2aiy2lUbs1S5+epLQXgEgv3YkCG6khbyiOXy9KDrvjNbJk4oW2IelmqjP3R0JKhl/Yw8ycw0Y7lkibI5NlUyXND5UqMXbF8gT0FYlDYUOMtYaHPYCELoHZo06Rtipazc8YZC7qVdJ1uFipZwaEvTf7fplFXN/lSJR1eE42uZnz6leH2bvAd3D0JS4o3QjmAdwbt6MqpEzPEAVPmKWMzsYifYaKHLD2lN3kFMMYhQKCbdZJUyX9NR8YCfX9QsHjQhEImH047bKlH1VF7V+9K/jwNvEjRszt3Gwa6aE2KVHIGU/uYcCA4p/m3UUzjd6gWuV1vZK9ZxfXNzxrmpULX7y03FSmOqwgyuShyBbEkEaKCM0AOtR9yAjTRbMcvyQjXBy5/kj5/PYSRaws8x3edOsVRH45qmLRPP1FWV6CG5Uw0hCFwxM70BKyeHZbl0auDcjpQe4nWjFenazpbEBYqABHsZoL6j+pm54lVFpMoq9qHRyJx4UcD06BqsQnXwvfdIPRbsEu+fnJ3kmletPi+VdoiZ2teK/B/Fa4wIWk0iO0WHVyXV6gmE2mDLxQXiQ=
+X-Forefront-PRVS: 04599F3534
+X-Forefront-Antispam-Report:
+	SFV:NSPM;SFS:(10009020)(50650200002)(4640300001)(4630300001)(376002)(346002)(199003)(189002)(377454003)(3905003)(1930700014)(319900001)(16586007)(42186006)(316002)(2906002)(97736004)(5660300001)(45080400002)(498600001)(9686003)(236005)(6306002)(86152003)(7350300001)(53946003)(53936002)(189998001)(606006)(74316002)(78352004)(2876002)(11286001)(84326002)(8676002)(733005)(68736007)(81156014)(81166006)(5320300001)(1706002)(33646002)(5008980100002)(31696002)(512954002)(74482002)(101416001)(83832001)(102106001)(54356999)(1476001)(50986999)(76176999)(260700001)(106356001)(2351001)(10126004)(89962001)(42882006)(6916009)(1496007)(2950100002)(105586002)(575784001)(82146005)(3720700003)(579004)(19627235001);DIR:OUT;SFP:1501;SCL:1;SRVR:DB5PR06MB1800;H:;FPR:;SPF:None;PTR:InfoNoRecords;A:0;MX:0;LANG:en;
+Received-SPF: None (protection.outlook.com:  does not designate permitted
+ sender hosts)
+Authentication-Results: spf=none (sender IP is ) smtp.mailfrom=<>; 
+X-Microsoft-Exchange-Diagnostics:
+	=?us-ascii?Q?1;DB5PR06MB1800;23:NjCK8s1zUT02wQGsJ2CdrbnwabySfTUX9zMn9i2lZ?=
+ =?us-ascii?Q?86er+5SHclSExb2PnSrjS+yW8Gs/0X85glw6Y6Q5DkAW6Gi0D96A8DxN2iu9?=
+ =?us-ascii?Q?QWpqVv/rLyoD2d3bC/bHOp7nX7gn0SaKES1TjmhcIYC8F4RWMu6MYo+5SJll?=
+ =?us-ascii?Q?bZNSQ4bDUeFPeK2g5pBVKsQGUqAtbTfl+pfzoXXQ0U1COIoFzu/hs6AG0UZC?=
+ =?us-ascii?Q?E8iolX+9pbs4YAEjBBVQL6doPrWd2jTW7c7og/SOMWK2BEJrOmlZNxzFZOYE?=
+ =?us-ascii?Q?ve74Y2owHpBKLsFFrkiw5jwv9UnEZUMiu0C/AKhVgAXXe5JxI8ojj7T48Gwh?=
+ =?us-ascii?Q?tDmZ1qqHmRwxHLt3tAhQ/DdaoPd8omFClM+wfYGChbkP82+2kYkWvAnzfqv9?=
+ =?us-ascii?Q?FkpiyZNBJTZ3ew7WT2KwnhSmVjLuxyIakTLGKqSt5UZ5qm/8xxlQQCH58stT?=
+ =?us-ascii?Q?oAdjwQMMp1zPu0ylztApEGU64jKZBr/qIWO4Rebso18y4zjGgbeloDRjpSHO?=
+ =?us-ascii?Q?K9dDyt1FCAULb+XZrO/kaWSzh+1FdCF36yCp4WlikQXif/D5CvDte9vibzyG?=
+ =?us-ascii?Q?zzeHKpx3XwTAl15BNDo2LKrV9IyLBFe6F4paInWwLHqgpx1jZbH6Tg6XFKPW?=
+ =?us-ascii?Q?C3/6InuaDk7nrF+DJq4cr25k4ZtdYj6kACz4Ej4GcP4IPJwSQ2fvisdAYZbN?=
+ =?us-ascii?Q?i1bbiuo+/20FnJ7FnIXJGdaFf20O+rj77qAvBivSdZXgTvNBw3CBCat4lfHX?=
+ =?us-ascii?Q?8KZ/LYP2iUsLBHVObn+3Z6F140PFZqhm453Z3J99tu0g/1uBJswN77w+aJWo?=
+ =?us-ascii?Q?laZjfiWFhySKAOORGOlL7lh3EPfym3tuKt8DIYM0rZ1hVGliXF8HRwgfentW?=
+ =?us-ascii?Q?Ae3GOhP0+ZXxY9jFrL7lJOWGMybCPtr4LKI8BFuxDp1QZJYkWevk401l4r6e?=
+ =?us-ascii?Q?93YMbj4Nk+yP/iS6DFHpTsMTHleWCD3Dgv13sjvF1Yp3Me01H5a0pbwN+deZ?=
+ =?us-ascii?Q?gSR0pocyfg0DJ2El54bCBtavOPU3L2sZzdS1qQhI9uXsa4B9z2aCzFwuimrS?=
+ =?us-ascii?Q?gnQ1hRzzxpTiI75k/ou3lIFQMbvVAMa0QnVzijZTxSISOREOU1KqNnL2i5lY?=
+ =?us-ascii?Q?uV6POv/NSvQozxQeO2JoJWE/7nxF9X/32GYP/+KCwz9sPSPs9pixwAVPJH7s?=
+ =?us-ascii?Q?kxGcagmSMiOrhDtJ5tfMVRDWG4dFDkcuN71wzjsJLF7J3s4Vu0sML8hQMSh1?=
+ =?us-ascii?Q?ydYuZmstoDhfrdNqtVuLBsM+6El8LS4XeG8BNCnwJadVhB2TLbX14ZgURuN3?=
+ =?us-ascii?Q?RrACGX8UVch3hA2P5U/QP1BZQz9sNv3F1c6Sc39FNIx2SkIk/F+ZxDAjZxyC?=
+ =?us-ascii?Q?01OWBjYKg7AHNivIVGlNNKlkJnA/q0M38cYKWPbzqbohonYw3ykSfOes+0m2?=
+ =?us-ascii?Q?Y7qoe9vwAle1k/cGKa7CQPNcH0CeR1hZgiT20D28ZMiSEwbApmuf7996u2lR?=
+ =?us-ascii?Q?KWcZ5OffrYgjpgGHzCLtTRCqF1FP/ochWGwETch/2DY7IsTfr7Zqk8PjKQwN?=
+ =?us-ascii?Q?MDe0bMb7XWcPPcG0/kAACamE1jzAW4aeou4RWI=3D?=
+X-Microsoft-Exchange-Diagnostics:
+	1;DB5PR06MB1800;6:UaLMB0qJyr3zR8wh/QFuB9Y1bQGWnBztVxtTw5Ww4qXFRaJDg/UsS/DhnON704Il6UQw2vi4qp5HILO3WQ4YF0EA+0kxI83OhIetEr4a9ob5jObSzrl/+vCkdKQkZ2ca4idTeFK7vkF8eqM5Rf9PQBIwhf4cWyHKjZ/LfiSt7T6WI++wQk4hFYKnwrJl14zR86JIqrpsdRyQA5gpkUqTgJ+klNvsEodhymKBTy15AEBHcISlmLJTl+hb4V0EdVttetw3t8oFqFJBSlVki/MdzUbB/I7Uz59nWDuOzXzvJMs6fRDAY9IfjXfbgd5iUdI7zZEzPVXSXFq2o8uqqt9ukg==;5:ISdbKPzzVo1/3SyCacWn4MXOrU4xmxaK+owU9N6AXTJfsu3jG21tv8sazHSE/n4hQhy1Jz6DoaZHNwUiY6IipJA1R54m+T08yxIBb/r12kjxAKELDOjpo8tzpi+mVq2fuPuMuhgvspLI2OoNZxF0ZA==;24:7jy/Z5IExXmvKPYun/2CEaiju2Mv9vefX3ypT3Dvw8SxuIQdViG/Y2gi6XMwYx2P5g5AgxMHk5IPwJxz53/CQS3UFzEtLu2ORDYbluSV9gE=;7:i78UKyffWC46GFNc3r9dRXlZwZn4uoZ3JdMBrH8nY64Of9nputUFhe2ihXO+sF8t6+aK8oFJFGLtUz3ShHbmE44CCfG/9UHRP7+zLqPbDfTX9vwrjmW235qRIx376Uf4Rs8gFbHrzHHqm3uFvPSfRZzGS++hMJ1CuT2zykEeYYHQupRzM0soNcZZROez3OFd0+5XdXWiFsqOTOPplXac3OeLgjo/+r6b0XlDwms1KKg=
+SpamDiagnosticOutput: 1:99
+SpamDiagnosticMetadata: NSPM
+X-OriginatorOrg: example.no
+X-MS-Exchange-CrossTenant-OriginalArrivalTime: 13 Oct 2017 11:10:16.7009
+ (UTC)
+X-MS-Exchange-CrossTenant-FromEntityHeader: Hosted
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: DB5PR06MB1800
+
+--22a54575-c842-43f3-83ea-721e8360fb4c
+Content-Type: multipart/alternative; differences=Content-Type;
+	boundary="75454191-d3d5-48ec-b8f1-8aa1d75d02e4"
+
+--75454191-d3d5-48ec-b8f1-8aa1d75d02e4
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+[http://products.office.com/en-us/CMSImages/Office365Logo_Orange.png?versio=
+n=3Db8d100a9-0a8b-8e6a-88e1-ef488fee0470]
+Your message to noname@example.com couldn't be delivered.
+
+noname wasn't found at example.com.
+
+postmaster      Office 365      noname
+Action Required                 Recipient
+
+
+Unknown To address
+
+
+How to Fix It
+The address may be misspelled or may not exist. Try one or more of the foll=
+owing:
+
+  *   Send the message again following these steps: In Outlook, open this n=
+on-delivery report (NDR) and choose Send Again from the Report ribbon. In O=
+utlook on the web, select this NDR, then select the link "To send this mess=
+age again, click here." Then delete and retype the entire recipient address=
+. If prompted with an Auto-Complete List suggestion don't select it. After =
+typing the complete address, click Send.
+  *   Contact the recipient (by phone, for example) to check that the addre=
+ss exists and is correct.
+  *   The recipient may have set up email forwarding to an incorrect addres=
+s. Ask them to check that any forwarding they've set up is working correctl=
+y.
+  *   Clear the recipient Auto-Complete List in Outlook or Outlook on the w=
+eb by following the steps in this article: Fix email delivery issues for er=
+ror code 5.1.10 in Office 365<http://go.microsoft.com/fwlink/?LinkId=3D5329=
+72>, and then send the message again. Retype the entire recipient address b=
+efore selecting Send.
+
+
+If the problem continues, forward this message to your email admin. If you'=
+re an email admin, refer to the More Info for Email Admins section below.
+
+
+Was this helpful? Send feedback to Microsoft<http://go.microsoft.com/fwlink=
+/?LinkId=3D525921>.
+________________________________
+
+
+More Info for Email Admins
+Status code: 550 5.1.10
+
+This error occurs because the sender sent a message to an email address hos=
+ted by Office 365 but the address is incorrect or doesn't exist at the dest=
+ination domain. The error is reported by the recipient domain's email serve=
+r, but most often it must be fixed by the person who sent the message. If t=
+he steps in the How to Fix It section above don't fix the problem, and you'=
+re the email admin for the recipient, try one or more of the following:
+
+The email address exists and is correct - Confirm that the recipient addres=
+s exists, is correct, and is accepting messages.
+
+Synchronize your directories - If you have a hybrid environment and are usi=
+ng directory synchronization make sure the recipient's email address is syn=
+ced correctly in both Office 365 and in your on-premises directory.
+
+Errant forwarding rule - Check for forwarding rules that aren't behaving as=
+ expected. Forwarding can be set up by an admin via mail flow rules or mail=
+box forwarding address settings, or by the recipient via the Inbox Rules fe=
+ature.
+
+Recipient has a valid license - Make sure the recipient has an Office 365 l=
+icense assigned to them. The recipient's email admin can use the Office 365=
+ admin center to assign a license (Users > Active Users > select the recipi=
+ent > Assigned License > Edit).
+
+Mail flow settings and MX records are not correct - Misconfigured mail flow=
+ or MX record settings can cause this error. Check your Office 365 mail flo=
+w settings to make sure your domain and any mail flow connectors are set up=
+ correctly. Also, work with your domain registrar to make sure the MX recor=
+ds for your domain are configured correctly.
+
+For more information and additional tips to fix this issue, see Fix email d=
+elivery issues for error code 5.1.10 in Office 365<http://go.microsoft.com/=
+fwlink/?LinkId=3D532972>.
+
+
+Original Message Details
+Created Date:   10/13/2017 11:10:12 AM
+Sender Address: postmaster@ninomail.com
+Recipient Address:      noname@example.com
+Subject:        test_bounce 8
+
+
+Error Details
+Reported error: 550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipient noname=
+@example.com not found by SMTP address lookup
+DSN generated by:       DB5PR06MB1800.eurprd06.prod.outlook.com
+
+
+Message Hops
+HOP     TIME (UTC)      FROM    TO      WITH    RELAY TIME
+1       10/13/2017
+11:10:11 AM             luna.mailgun.net        HTTP    *
+2       10/13/2017
+11:10:13 AM     dfw-p103.ninomail.com   inpreemea2.hes.trendmicro.eu    ESM=
+TPS  2 sec
+3       10/13/2017
+11:10:14 AM     209.61.154.103_hes.trendmicro.com       ioutemea3.hes.trend=
+micro.eu     SMTP    1 sec
+4       10/13/2017
+11:10:14 AM     ioutemea3.hes.trendmicro.eu     HE1EUR01FT040.mail.protecti=
+on.outlook.com       Microsoft SMTP Server (version=3DTLS1_2, cipher=3DTLS_=
+ECDHE_RSA_WITH_AES_256_CBC_SHA384_P384)       *
+5       10/13/2017
+11:10:15 AM     HE1EUR01FT040.eop-EUR01.prod.protection.outlook.com     VI1=
+PR0601CA0032.outlook.office365.com   Microsoft SMTP Server (version=3DTLS1_=
+2, cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256)       1 sec
+6       10/13/2017
+11:10:16 AM     VI1PR0601CA0032.eurprd06.prod.outlook.com       DB5PR06MB18=
+00.eurprd06.prod.outlook.com Microsoft SMTP Server (version=3DTLS1_2, ciphe=
+r=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256)       1 sec
+
+Original Message Headers
+
+Received: from VI1PR0601CA0032.eurprd06.prod.outlook.com
+ (2603:10a6:800:1e::42) by DB5PR06MB1800.eurprd06.prod.outlook.com
+ (2a01:111:e400:7905::18) with Microsoft SMTP Server (version=3DTLS1_2,
+ cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id 15.20.77.7; Fri, 1=
+3 Oct
+ 2017 11:10:16 +0000
+Received: from HE1EUR01FT040.eop-EUR01.prod.protection.outlook.com
+ (2a01:111:f400:7e1f::206) by VI1PR0601CA0032.outlook.office365.com
+ (2603:10a6:800:1e::42) with Microsoft SMTP Server (version=3DTLS1_2,
+ cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id 15.20.77.7 via Fro=
+ntend
+ Transport; Fri, 13 Oct 2017 11:10:15 +0000
+Authentication-Results: spf=3Dsoftfail (sender IP is 52.58.62.203)
+ smtp.mailfrom=3Dninomail.com; example.com; dkim=3Dpass (signature was
+ verified) header.d=3Dninomail.com;example.com; dmarc=3Dnone action=3Dn=
+one
+ header.from=3Dmailgunhq.com;
+Received-SPF: SoftFail (protection.outlook.com: domain of transitioning
+ ninomail.com discourages use of 52.58.62.203 as permitted sender)
+Received: from ioutemea3.hes.trendmicro.eu (52.58.62.203) by
+ HE1EUR01FT040.mail.protection.outlook.com (10.152.1.72) with Microsoft SMT=
+P
+ Server (version=3DTLS1_2, cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P=
+384) id
+ 15.20.77.10 via Frontend Transport; Fri, 13 Oct 2017 11:10:14 +0000
+Received: from 209.61.154.103_hes.trendmicro.com (unknown [192.168.13.217])
+        by ioutemea3.hes.trendmicro.eu (Postfix) with SMTP id 749FD11200E
+        for <noname@example.com>; Fri, 13 Oct 2017 11:10:14 +0000 (UTC)
+Received: from dfw-p103.ninomail.com (unknown [209.61.154.103])
+        by inpreemea2.hes.trendmicro.eu (Postfix) with ESMTPS id 2D9022EE05=
+E
+        for <noname@example.com>; Fri, 13 Oct 2017 11:10:13 +0000 (UTC)
+DKIM-Signature: a=3Drsa-sha256; v=3D1; c=3Drelaxed/relaxed; d=3Dninomail.co=
+m; q=3Ddns/txt; s=3Dmx;
+ t=3D1507893012; h=3DContent-Transfer-Encoding: Mime-Version: Content-Type:
+ Subject: From: To: Message-Id: List-Unsubscribe: Date;
+ bh=3DZ0RRkWGMZ95HQdCnkNkIEgrcz3FH2ScG0r54JXFR3Vw=3D; b=3DArQ3Q8lB0KCJxNGU0=
+uwQe8mnOWDTlOi+T0lie9zlMs/kk7xgbuJBtt0xfE40o/gIlYENQ5VV
+ yrubfcZ0JTnszpw2QJVLJs/ETig+ZA10qRXR7P+EwzbyCI7XEneMrcwQsBFbrDBHiMVsPCws
+ 6Sppee8wcuTNbWfkdOhbY8xpQ/o=3D
+DomainKey-Signature: a=3Drsa-sha1; c=3Dnofws; d=3Dninomail.com; s=3Dmx; q=
+=3Ddns;
+ h=3DDate: List-Unsubscribe: Message-Id: To: From: Subject: Content-Type:
+ Mime-Version: Content-Transfer-Encoding;
+ b=3DkeeX65FWYAvnsAB/PT4Bwv5z2gZlber/+lccOi3sEbbWy+dBP58bVTxMju9kTjV5FR8Nix
+ ePnEngG56ziSjkEXiPLI2bIfLYZf0sByiB4giyTlejQW4su2ymBVfIX0pj/P9TT/Hk24ZtPF
+ DFQfd2DXdV+ssayd7A0boyiqyrrOk=3D
+Date: Fri, 13 Oct 2017 11:10:12 +0000
+X-Mailgun-Sending-Ip: 209.61.154.103
+X-Mailgun-Sid: WyJlYjg3MCIsICJob3JraGVAc3VwZXJvZmZpY2UuY29tIiwgIjYiXQ=3D=3D
+List-Unsubscribe: <mailto:u+mq6tmjtjhuzdamjxgeydcmzrgeytamjrfyzdaobwgyxdenj=
+uimzemm2bgrcdoqkbguzdmjjugbxgs3tpnvqws3bomnxw2jtihu4gcnjxgjrgmzbtgu2wezrvga=
+zgeolemiydonbvgqzwiyjxmq3dojtshvug64tlnbssknbqon2xazlsn5tgm2ldmuxgg33nez2d2=
+jjsie@ninomail.com>
+Received: by luna.mailgun.net with HTTP; Fri, 13 Oct 2017 11:10:11 +0000
+Message-ID: <20171013111011.20866.254C2F3A4D7AA526@ninomail.com>
+X-Mailgun-Native-Send: yes
+To: noname@example.com
+From: noname@mailgunhq.com
+Subject: test_bounce 8
+Content-Type: text/plain; charset=3D"ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-TM-Received-SPF: Pass (domain of postmaster@ninomail.com designates
+        209.61.154.103 as permitted sender) client-ip=3D209.61.154.103;
+        envelope-from=3Dpostmaster@ninomail.com; helo=3Ddfw-p103.ninomail.c=
+om
+X-TMASE-Version: StarCloud-1.3-8.2.1006-23392.006
+X-TMASE-Result: 10--2.729200-10.000000
+X-TMASE-MatchedRID: GooOU10L43zav6YmtDxNqNFig1NpvMlDPuK6nXzgR1TnBDF/TMnTXjJ=
+l
+        3MhaKU4m4vM1YF6AJbaKoonP3ywz3Y4dBcJ6M5YH0ddkKKNSSi9XH0VVrOHyJe2tcfd=
+uZIOv3Qf
+        wsVk0UbtQ1faGnRfEeCS6ICxj5PROYkrzZvAd3CfT4GfHkFXnynlApuqqC+djwaBvbB=
+px3eXfDq
+        qb3XQ/hue1U/Euj8bPgviCrXu93JNzjSufs2oTAvK4cKjK2vlq8OTZexKs73Ol3wq8b=
+Gz2prEkr
+        SbZSQWFUBAqBajX2hg=3D
+X-TMASE-SNAP-Result: 1.821001.0001-0-1-12:0,22:0,33:0,34:0,39:0-0
+X-TM-Deliver-Signature: A1F966477493E8CC077EFBFD2963EE52
+Return-Path: postmaster@ninomail.com
+X-EOPAttributedMessage: 0
+X-EOPTenantAttributedMessage: caef7785-c073-4453-8b47-6432b6b5b10f:0
+X-Forefront-Antispam-Report: CIP:52.58.62.203;IPV:NLI;CTRY:US;EFV:NLI;
+X-Microsoft-Exchange-Diagnostics: 1;HE1EUR01FT040;1:8Yfy3RCcMtWjd2wHETuKGgb=
+YvMhwEmz4LIe9f7oSB4tp7h0z7cACxryH+0M3NT8qJ2/j7nTdwkEifFRCFkEmVm/8U0MfnxdPin=
+eDdDC5D9GGTRKhxkl4L+aROlRj/J3a
+X-MS-PublicTrafficType: Email
+X-MS-Office365-Filtering-Correlation-Id: c68ecd6c-bb49-4ed3-2782-08d5122afa=
+fa
+X-DkimResult-Test: Passed
+X-Microsoft-Antispam:
+        UriScan:;BCL:0;PCL:0;RULEID:(22001)(23075)(421252002)(3001016)(7170=
+2078);SRVR:DB5PR06MB1800;
+X-Microsoft-Exchange-Diagnostics:
+        1;DB5PR06MB1800;3:eIUBG2d+QhGEssrKUk0vR7Qo1xBaLzxFYKXinPbtC3lbNOOKl=
+0ptZ6Dwpd5/OvUk0hZRjDmU0H0A+3+cYAwCf+XK0aF+w/f/0BM1HB6RqZvKasYY4skANmQh1SUI=
+E3/NlmmfNUCPAXe2mYko5gjHS3FWfNfn5JUpUc0uqi1CiQZuz75UkMI1StjnNztymn4Poa04bv3=
+29Q323gfsNJDTRWxvCNmrgSBqavZ85LE43+/3tXAXH25lu0HWaLJbf+P7M91/9m1dGEE3lE9BSH=
+AgsW5mxY0Rgk9Cfi44Cz2zJn1W5JH5LJ2aR7fnETCIBMSnTmU9lskn5OxBoBsug3J1sg=3D=3D;=
+25:QhToXBW84g8b1E0tDQz1wlgKZHT3MfBBXPqER0vHXiVfl5tgVG8PQ9vjAYKosqQIh25bjvo5=
+I/HrmLe8XFOg6bYQI/VrzqPSE6wBZTZ+nZ8dFdyWwRSbX85RKC9pm62yFaIbsOkta1xF/q8CE5n=
+yFkKfUxHt9vHosW4IrzT7+w8XAhh0VqhUYOvk4Cp1St3M8L8GAu90Dj3kaupTwZhxUxVkYVewyc=
+8xb74anpZIASat5MjRVcVH26j5EUwN24Ko1RUunp7SXLydpXqJKUJcxjbJe6absxj+5Fb2GzCQh=
++k/9quBIDXusyO9MsAorZoZMVUVl/pmy/6V/KYy9AfpsAgvXvZoa31ftGl2wTt6t3k=3D
+X-MS-TrafficTypeDiagnostic: DB5PR06MB1800:
+
+
+--75454191-d3d5-48ec-b8f1-8aa1d75d02e4
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+  <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=3D=
+1" />
+  <head>
+    <title>
+          DSN
+        </title>
+  </head>
+  <body style=3D"        background-color: white;      ">
+    <table style=3D"        background-color: white;         max-width: 548=
+px;         color: black;         border-spacing: 0px 0px;         padding-=
+top: 0px;         padding-bottom: 0px;        border-collapse: collapse;   =
+   " width=3D"548" cellspacing=3D"0" cellpadding=3D"0">
+      <tbody>
+        <tr>
+          <td style=3D"        text-align: left;        padding-bottom: 20p=
+x;      ">
+            <img height=3D"28" width=3D"126" style=3D"        max-width: 10=
+0%;      " src=3D"http://products.office.com/en-us/CMSImages/Office365Logo_=
+Orange.png?version=3Db8d100a9-0a8b-8e6a-88e1-ef488fee0470" />
+          </td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;        font-size: 16px;         padding-bottom: 10px;         -ms=
+-text-size-adjust: 100%;        text-align: left;      ">Your message to <s=
+pan style=3D"        color: #0072c6;      ">noname@example.com</span> c=
+ouldn't be delivered.<br /></td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;         font-size: 24px;         padding-top: 0px;         paddin=
+g-bottom: 20px;         text-align: center;         -ms-text-size-adjust: 1=
+00%;      ">
+            <span style=3D"        color: #0072c6;      ">noname</span> was=
+n't found at <span style=3D"        color: #0072c6;      ">example.com<=
+/span>.<br /></td>
+        </tr>
+        <tr>
+          <td style=3D"        padding-bottom: 15px;         padding-left: =
+0px;         padding-right: 0px;         border-spacing: 0px 0px;      ">
+            <table style=3D"        max-width: 548px;         font-weight: =
+600;        border-spacing: 0px 0px;         padding-top: 0px;         padd=
+ing-bottom: 0px;        border-collapse: collapse;      ">
+              <tbody>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        font-size: 15px;        font-weight: 600;        t=
+ext-align: left;        width: 181px;        -ms-text-size-adjust: 100%;   =
+     vertical-align: bottom;      ">
+                    <font color=3D"#ffffff">
+                      <span style=3D"color:#000000">postmaster</span>
+                    </font>
+                  </td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        font-size: 15px;        font-weight: 600;        t=
+ext-align: center;        width: 186px;        -ms-text-size-adjust: 100%; =
+       vertical-align: bottom;      ">
+                    <font color=3D"#ffffff">
+                      <span style=3D"color:#000000">Office 365</span>
+                    </font>
+                  </td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;         -ms-text-size-adjust: 100%;         font-size: 15=
+px;         font-weight: 600;        text-align: right;         width: 181p=
+x;         vertical-align: bottom;      ">
+                    <font color=3D"#ffffff">
+                      <span style=3D"color:#000000">noname</span>
+                    </font>
+                  </td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;        text-align: left;        padding-top: 0px=
+;        padding-bottom: 0px;        vertical-align: middle;        width: =
+181px;      ">
+                    <font color=3D"#ffffff">
+                      <span style=3D"        color: #c00000;      ">
+                        <b>Action Required</b>
+                      </span>
+                    </font>
+                  </td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;        text-align: center;        padding-top: 0=
+px;        padding-bottom: 0px;        vertical-align: middle;        width=
+: 186px;      " />
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;        text-align: right;        padding-top: 0p=
+x;        padding-bottom: 0px;        vertical-align: middle;        width:=
+ 181px;      ">
+                    <font color=3D"#ffffff">
+                      <span style=3D"color:#000000">Recipient</span>
+                    </font>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan=3D"3" style=3D"        padding-top:0;        =
+padding-bottom:0;        padding-left:0;        padding-right:0      ">
+                    <table cellspacing=3D"0" cellpadding=3D"0" style=3D"   =
+     border-spacing: 0px 0px;        padding-top: 0px;        padding-botto=
+m: 0px;        padding-left: 0px;        padding-right: 0px;        border-=
+collapse: collapse;      ">
+                      <tbody>
+                        <tr height=3D"10">
+                          <td width=3D"180" height=3D"10" bgcolor=3D"#c0000=
+0" style=3D"        width: 180px;        line-height: 10px;        height: =
+10px;        font-size: 6px;        padding-top: 0;        padding-bottom: =
+0;        padding-left: 0;        padding-right: 0;      "><!--[if gte mso =
+15]>&nbsp;<![endif]--></td>
+                          <td width=3D"4" height=3D"10" bgcolor=3D"#ffffff"=
+ style=3D"        width: 4px;        line-height: 10px;        height: 10px=
+;        font-size: 6px;        padding-top: 0;        padding-bottom: 0;  =
+      padding-left: 0;        padding-right: 0;      "><!--[if gte mso 15]>=
+&nbsp;<![endif]--></td>
+                          <td width=3D"180" height=3D"10" bgcolor=3D"#ccccc=
+c" style=3D"        width: 180px;        line-height: 10px;        height: =
+10px;        font-size: 6px;        padding-top: 0;        padding-bottom: =
+0;        padding-left: 0;        padding-right: 0;      "><!--[if gte mso =
+15]>&nbsp;<![endif]--></td>
+                          <td width=3D"4" height=3D"10" bgcolor=3D"#ffffff"=
+ style=3D"        width: 4px;        line-height: 10px;        height: 10px=
+;        font-size: 6px;        padding-top: 0;        padding-bottom: 0;  =
+      padding-left: 0;        padding-right: 0;      "><!--[if gte mso 15]>=
+&nbsp;<![endif]--></td>
+                          <td width=3D"180" height=3D"10" bgcolor=3D"#ccccc=
+c" style=3D"        width: 180px;        line-height: 10px;        height: =
+10px;        font-size: 6px;        padding-top: 0;        padding-bottom: =
+0;        padding-left: 0;        padding-right: 0;      "><!--[if gte mso =
+15]>&nbsp;<![endif]--></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        text-align: left;        width: 181px;        line-height: 20px;  =
+      font-weight: 400;        padding-top: 0px;        padding-left: 0px; =
+       padding-right: 0px;        padding-bottom: 0px;      ">
+                    <font color=3D"#ffffff">
+                      <span style=3D"        color: #c00000;      ">Unknown=
+ To address</span>
+                    </font>
+                  </td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        text-align: center;        width: 186px;        line-height: 20px;=
+        font-weight: 400;        padding-top: 0px;        padding-left: 0px=
+;        padding-right: 0px;        padding-bottom: 0px;      " />
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        text-align: right;        width: 181px;        line-height: 20px; =
+       font-weight: 400;        padding-top: 0px;        padding-left: 0px;=
+        padding-right: 0px;        padding-bottom: 0px;      " />
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style=3D"        width: 100%;        padding-top: 0px;       =
+ padding-right: 10px;        padding-left: 10px;      ">
+            <br />
+            <table style=3D"        width: 100%;        padding-right: 0px;=
+        padding-left: 0px;        padding-top: 0px;        padding-bottom: =
+0px;        background-color: #f2f5fa;        margin-left: 0px;      ">
+              <tbody>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 21px=
+;        font-weight: 500;        background-color: #f2f5fa;        padding=
+-top: 0px;        padding-bottom: 0px;        padding-left: 10px;        pa=
+dding-right: 10px;      ">How to Fix It</td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 16px=
+;        font-weight: 400;        padding-top: 0px;        padding-bottom: =
+6px;        padding-left: 10px;        padding-right: 10px;        backgrou=
+nd-color: #f2f5fa;      ">The address may be misspelled or may not exist. T=
+ry one or more of the following:</td>
+                </tr>
+                <tr>
+                  <td style=3D"         padding-top: 0px;         padding-b=
+ottom: 0px;         padding-left: 0px;         padding-right: 0px;        b=
+order-spacing: 0px 0px;      ">
+                    <ul style=3D"        font-family: 'Segoe UI', Frutiger,=
+ Arial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 16=
+px;        font-weight: 400;        margin-left: 40px;        margin-bottom=
+: 5px;        background-color: #f2f5fa;        padding-top: 0px;        pa=
+dding-bottom: 0px;        padding-left: 6px;        padding-right: 6px;    =
+  ">
+                      <li>Send the message again following these steps: In =
+Outlook, open this non-delivery report (NDR) and choose <b>Send Again</b> f=
+rom the Report ribbon. In Outlook on the web, select this NDR, then select =
+the link "<b>To send this message again, click here.</b>" Then delete and r=
+etype the entire recipient address. If prompted with an Auto-Complete List =
+suggestion don't select it. After typing the complete address, click <b>Sen=
+d</b>.</li>
+                      <li>Contact the recipient (by phone, for example) to =
+check that the address exists and is correct.</li>
+                      <li>The recipient may have set up email forwarding to=
+ an incorrect address. Ask them to check that any forwarding they've set up=
+ is working correctly.</li>
+                      <li>Clear the recipient Auto-Complete List in Outlook=
+ or Outlook on the web by following the steps in this article: <a href=3D"h=
+ttp://go.microsoft.com/fwlink/?LinkId=3D532972">Fix email delivery issues f=
+or error code 5.1.10 in Office 365</a>, and then send the message again. Re=
+type the entire recipient address before selecting <b>Send</b>.</li>
+                    </ul>
+                  </td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 16px=
+;        font-weight: 400;        padding-top: 0px;        padding-bottom: =
+6px;        padding-left: 10px;        padding-right: 10px;        backgrou=
+nd-color: #f2f5fa;      ">If the problem continues, forward this message to=
+ your email admin. If you're an email admin, refer to the <b>More Info for =
+Email Admins</b> section below.</td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;        -ms-text-size-adjust: 100%;        font-size: 14px;       =
+ font-weight: 400;        padding-top: 10px;        padding-bottom: 0px;   =
+     padding-bottom: 4px;      ">
+            <br />
+            <em>Was this helpful? <a href=3D"http://go.microsoft.com/fwlink=
+/?LinkId=3D525921">Send feedback to Microsoft</a>.</em>
+          </td>
+        </tr>
+        <tr>
+          <td style=3D"        -ms-text-size-adjust: 100%;        font-size=
+: 0px;        line-height: 0px;        padding-top: 0px;        padding-bot=
+tom: 0px;      ">
+            <hr />
+          </td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;        -ms-text-size-adjust: 100%;        font-size: 21px;       =
+ font-weight: 500;      ">
+            <br />More Info for Email Admins</td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;        -ms-text-size-adjust: 100%;        font-size: 14px;      "=
+>
+            <em>Status code: 550 5.1.10</em>
+            <br />
+            <br />This error occurs because the sender sent a message to an=
+ email address hosted by Office 365 but the address is incorrect or doesn't=
+ exist at the destination domain. The error is reported by the recipient do=
+main's email server, but most often it must be fixed by the person who sent=
+ the message. If the steps in the <b>How to Fix It</b> section above don't =
+fix the problem, and you're the email admin for the recipient, try one or m=
+ore of the following:<br /><br /><b>The email address exists and is correct=
+</b> - Confirm that the recipient address exists, is correct, and is accept=
+ing messages.<br /><br /><b>Synchronize your directories</b> - If you have =
+a hybrid environment and are using directory synchronization make sure the =
+recipient's email address is synced correctly in both Office 365 and in you=
+r on-premises directory.<br /><br /><b>Errant forwarding rule</b> - Check f=
+or forwarding rules that aren't behaving as expected. Forwarding can be set=
+ up by an admin via mail flow rules or mailbox forwarding address settings,=
+ or by the recipient via the Inbox Rules feature.<br /><br /><b>Recipient h=
+as a valid license</b> - Make sure the recipient has an Office 365 license =
+assigned to them. The recipient's email admin can use the Office 365 admin =
+center to assign a license (Users &gt; Active Users &gt; select the recipie=
+nt &gt; Assigned License &gt; Edit).<br /><br /><b>Mail flow settings and M=
+X records are not correct</b> - Misconfigured mail flow or MX record settin=
+gs can cause this error. Check your Office 365 mail flow settings to make s=
+ure your domain and any mail flow connectors are set up correctly. Also, wo=
+rk with your domain registrar to make sure the MX records for your domain a=
+re configured correctly.<br /><br />For more information and additional tip=
+s to fix this issue, see <a href=3D"http://go.microsoft.com/fwlink/?LinkId=
+=3D532972">Fix email delivery issues for error code 5.1.10 in Office 365</a=
+>.<br /><br /></td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;        -ms-text-size-adjust: 100%;        font-size: 17px;       =
+ font-weight: 500;      ">Original Message Details</td>
+        </tr>
+        <tr>
+          <td style=3D"        font-size: 14px;        line-height: 20px;  =
+      font-family: 'Segoe UI', Frutiger, Arial, sans-serif;        -ms-text=
+-size-adjust: 100%;        font-weight: 500;      ">
+            <table style=3D"        width: 100%;        border-collapse: co=
+llapse;        margin-left: 10px;      ">
+              <tbody>
+                <tr>
+                  <td valign=3D"top" style=3D"        font-family: 'Segoe U=
+I', Frutiger, Arial, sans-serif;        font-size: 14px;        -ms-text-si=
+ze-adjust: 100%;        white-space: nowrap;        font-weight: 500;      =
+  width: 140px;      ">Created Date:</td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;      ">10/13/2017 11:10:12 AM</td>
+                </tr>
+                <tr>
+                  <td valign=3D"top" style=3D"        font-family: 'Segoe U=
+I', Frutiger, Arial, sans-serif;        font-size: 14px;        -ms-text-si=
+ze-adjust: 100%;        white-space: nowrap;        font-weight: 500;      =
+  width: 140px;      ">Sender Address:</td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;      ">postmaster@ninomail.com</td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        font-size: 14px;        -ms-text-size-adjust: 100%=
+;        white-space: nowrap;        font-weight: 500;        width: 140px;=
+      ">Recipient Address:</td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;      ">noname@example.com</td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        font-size: 14px;        -ms-text-size-adjust: 100%=
+;        white-space: nowrap;        font-weight: 500;        width: 140px;=
+      ">Subject:</td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;      ">test_bounce 8</td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sa=
+ns-serif;        -ms-text-size-adjust: 100%;        font-size: 17px;       =
+ font-weight: 500;      ">
+            <br />Error Details</td>
+        </tr>
+        <tr>
+          <td style=3D"        font-size: 14px;        line-height: 20px;  =
+      font-family: 'Segoe UI', Frutiger, Arial, sans-serif;        -ms-text=
+-size-adjust: 100%;        font-weight: 500;      ">
+            <table style=3D"        width: 100%;        border-collapse: co=
+llapse;        margin-left: 10px;      ">
+              <tbody>
+                <tr>
+                  <td valign=3D"top" style=3D"        font-family: 'Segoe U=
+I', Frutiger, Arial, sans-serif;        font-size: 14px;        -ms-text-si=
+ze-adjust: 100%;        white-space: nowrap;        font-weight: 500;      =
+  width: 140px;      ">Reported error:</td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;      ">
+                    <em>550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipien=
+t noname@example.com not found by SMTP address lookup</em>
+                  </td>
+                </tr>
+                <tr>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        font-size: 14px;        -ms-text-size-adjust: 100%=
+;        white-space: nowrap;        font-weight: 500;        width: 140px;=
+      ">DSN generated by:</td>
+                  <td style=3D"        font-family: 'Segoe UI', Frutiger, A=
+rial, sans-serif;        -ms-text-size-adjust: 100%;        font-size: 14px=
+;        font-weight: 400;      ">DB5PR06MB1800.eurprd06.prod.outlook.com</=
+td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <br />
+    <table style=3D"width: 880px;" cellspacing=3D"0">
+      <tr>
+        <td colspan=3D"6" style=3D"        padding-top: 4px;        border-=
+bottom: 1px solid #999999;        padding-bottom: 4px;        line-height: =
+120%;        font-size: 17px;        font-family: 'Segoe UI', Frutiger, Ari=
+al, sans-serif;        -ms-text-size-adjust: 100%;        font-weight: 500;=
+      ">Message Hops</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        background-color: #f2f5fa;        border-bottom: 1p=
+x solid #999999;        white-space: nowrap;        padding: 8px;      ">HO=
+P</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        background-color: #f2f5fa;        border-bottom: 1p=
+x solid #999999;        white-space: nowrap;        padding: 8px;        wi=
+dth: 80px;      ">TIME (UTC)</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        background-color: #f2f5fa;        border-bottom: 1p=
+x solid #999999;        white-space: nowrap;        padding: 8px;      ">FR=
+OM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        background-color: #f2f5fa;        border-bottom: 1p=
+x solid #999999;        white-space: nowrap;        padding: 8px;      ">TO=
+</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        background-color: #f2f5fa;        border-bottom: 1p=
+x solid #999999;        white-space: nowrap;        padding: 8px;      ">WI=
+TH</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        background-color: #f2f5fa;        border-bottom: 1p=
+x solid #999999;        white-space: nowrap;        padding: 8px;      ">RE=
+LAY TIME</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: center;      ">1</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;        width: 80px;      ">10/13/2017<br />11:=
+10:11 AM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      "></td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">luna.mailgun.net</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">HTTP</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">*</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: center;      ">2</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;        width: 80px;      ">10/13/2017<br />11:=
+10:13 AM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">dfw-p103.ninomail.com</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">inpreemea2.hes.trendmicro.eu</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">ESMTPS</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">2&nbsp;sec</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: center;      ">3</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;        width: 80px;      ">10/13/2017<br />11:=
+10:14 AM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">209.61.154.103_hes.trendmicro.com</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">ioutemea3.hes.trendmicro.eu</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">SMTP</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">1&nbsp;sec</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: center;      ">4</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;        width: 80px;      ">10/13/2017<br />11:=
+10:14 AM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">ioutemea3.hes.trendmicro.eu</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">HE1EUR01FT040.mail.protection.outlook.c=
+om</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">Microsoft SMTP Server (version=3DTLS1_2=
+, cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P384)</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">*</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: center;      ">5</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;        width: 80px;      ">10/13/2017<br />11:=
+10:15 AM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">HE1EUR01FT040.eop-EUR01.prod.protection=
+.outlook.com</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">VI1PR0601CA0032.outlook.office365.com</=
+td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">Microsoft SMTP Server (version=3DTLS1_2=
+, cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256)</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">1&nbsp;sec</td>
+      </tr>
+      <tr>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: center;      ">6</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;        width: 80px;      ">10/13/2017<br />11:=
+10:16 AM</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">VI1PR0601CA0032.eurprd06.prod.outlook.c=
+om</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">DB5PR06MB1800.eurprd06.prod.outlook.com=
+</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">Microsoft SMTP Server (version=3DTLS1_2=
+, cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256)</td>
+        <td style=3D"        font-size: 12px;        font-family: 'Segoe UI=
+', Frutiger, Arial, sans-serif;        -ms-text-size-adjust: 100%;        f=
+ont-weight: 500;        border-bottom: 1px solid #999999;        padding: 8=
+px;        text-align: left;      ">1&nbsp;sec</td>
+      </tr>
+    </table>
+    <p style=3D"        font-family: 'Segoe UI', Frutiger, Arial, sans-seri=
+f;        -ms-text-size-adjust: 100%;        font-size: 17px;        font-w=
+eight: 500;        padding-top: 4px;        padding-bottom: 0;        margi=
+n-top: 19px;        margin-bottom: 5px;      ">Original Message Headers</p>
+    <pre style=3D"        color: gray;        white-space: pre;        padd=
+ing-top: 0;        margin-top: 5px;      ">Received: from VI1PR0601CA0032.e=
+urprd06.prod.outlook.com
+ (2603:10a6:800:1e::42) by DB5PR06MB1800.eurprd06.prod.outlook.com
+ (2a01:111:e400:7905::18) with Microsoft SMTP Server (version=3DTLS1_2,
+ cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id 15.20.77.7; Fri, 1=
+3 Oct
+ 2017 11:10:16 +0000
+Received: from HE1EUR01FT040.eop-EUR01.prod.protection.outlook.com
+ (2a01:111:f400:7e1f::206) by VI1PR0601CA0032.outlook.office365.com
+ (2603:10a6:800:1e::42) with Microsoft SMTP Server (version=3DTLS1_2,
+ cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id 15.20.77.7 via Fro=
+ntend
+ Transport; Fri, 13 Oct 2017 11:10:15 +0000
+Authentication-Results: spf=3Dsoftfail (sender IP is 52.58.62.203)
+ smtp.mailfrom=3Dninomail.com; example.com; dkim=3Dpass (signature was
+ verified) header.d=3Dninomail.com;example.com; dmarc=3Dnone action=3Dn=
+one
+ header.from=3Dmailgunhq.com;
+Received-SPF: SoftFail (protection.outlook.com: domain of transitioning
+ ninomail.com discourages use of 52.58.62.203 as permitted sender)
+Received: from ioutemea3.hes.trendmicro.eu (52.58.62.203) by
+ HE1EUR01FT040.mail.protection.outlook.com (10.152.1.72) with Microsoft SMT=
+P
+ Server (version=3DTLS1_2, cipher=3DTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P=
+384) id
+ 15.20.77.10 via Frontend Transport; Fri, 13 Oct 2017 11:10:14 +0000
+Received: from 209.61.154.103_hes.trendmicro.com (unknown [192.168.13.217])
+	by ioutemea3.hes.trendmicro.eu (Postfix) with SMTP id 749FD11200E
+	for &lt;noname@example.com&gt;; Fri, 13 Oct 2017 11:10:14 +0000 (UTC)
+Received: from dfw-p103.ninomail.com (unknown [209.61.154.103])
+	by inpreemea2.hes.trendmicro.eu (Postfix) with ESMTPS id 2D9022EE05E
+	for &lt;noname@example.com&gt;; Fri, 13 Oct 2017 11:10:13 +0000 (UTC)
+DKIM-Signature: a=3Drsa-sha256; v=3D1; c=3Drelaxed/relaxed; d=3Dninomail.co=
+m; q=3Ddns/txt; s=3Dmx;
+ t=3D1507893012; h=3DContent-Transfer-Encoding: Mime-Version: Content-Type:
+ Subject: From: To: Message-Id: List-Unsubscribe: Date;
+ bh=3DZ0RRkWGMZ95HQdCnkNkIEgrcz3FH2ScG0r54JXFR3Vw=3D; b=3DArQ3Q8lB0KCJxNGU0=
+uwQe8mnOWDTlOi+T0lie9zlMs/kk7xgbuJBtt0xfE40o/gIlYENQ5VV
+ yrubfcZ0JTnszpw2QJVLJs/ETig+ZA10qRXR7P+EwzbyCI7XEneMrcwQsBFbrDBHiMVsPCws
+ 6Sppee8wcuTNbWfkdOhbY8xpQ/o=3D
+DomainKey-Signature: a=3Drsa-sha1; c=3Dnofws; d=3Dninomail.com; s=3Dmx; q=
+=3Ddns;
+ h=3DDate: List-Unsubscribe: Message-Id: To: From: Subject: Content-Type:
+ Mime-Version: Content-Transfer-Encoding;
+ b=3DkeeX65FWYAvnsAB/PT4Bwv5z2gZlber/+lccOi3sEbbWy+dBP58bVTxMju9kTjV5FR8Nix
+ ePnEngG56ziSjkEXiPLI2bIfLYZf0sByiB4giyTlejQW4su2ymBVfIX0pj/P9TT/Hk24ZtPF
+ DFQfd2DXdV+ssayd7A0boyiqyrrOk=3D
+Date: Fri, 13 Oct 2017 11:10:12 +0000
+X-Mailgun-Sending-Ip: 209.61.154.103
+X-Mailgun-Sid: WyJlYjg3MCIsICJob3JraGVAc3VwZXJvZmZpY2UuY29tIiwgIjYiXQ=3D=3D
+List-Unsubscribe: &lt;mailto:u+mq6tmjtjhuzdamjxgeydcmzrgeytamjrfyzdaobwgyxd=
+enjuimzemm2bgrcdoqkbguzdmjjugbxgs3tpnvqws3bomnxw2jtihu4gcnjxgjrgmzbtgu2wezr=
+vgazgeolemiydonbvgqzwiyjxmq3dojtshvug64tlnbssknbqon2xazlsn5tgm2ldmuxgg33nez=
+2d2jjsie@ninomail.com&gt;
+Received: by luna.mailgun.net with HTTP; Fri, 13 Oct 2017 11:10:11 +0000
+Message-ID: &lt;20171013111011.20866.254C2F3A4D7AA526@ninomail.com&gt;
+X-Mailgun-Native-Send: yes
+To: noname@example.com
+From: noname@mailgunhq.com
+Subject: test_bounce 8
+Content-Type: text/plain; charset=3D"ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-TM-Received-SPF: Pass (domain of postmaster@ninomail.com designates=20
+	209.61.154.103 as permitted sender) client-ip=3D209.61.154.103;=20
+	envelope-from=3Dpostmaster@ninomail.com; helo=3Ddfw-p103.ninomail.com
+X-TMASE-Version: StarCloud-1.3-8.2.1006-23392.006
+X-TMASE-Result: 10--2.729200-10.000000
+X-TMASE-MatchedRID: GooOU10L43zav6YmtDxNqNFig1NpvMlDPuK6nXzgR1TnBDF/TMnTXjJ=
+l
+	3MhaKU4m4vM1YF6AJbaKoonP3ywz3Y4dBcJ6M5YH0ddkKKNSSi9XH0VVrOHyJe2tcfduZIOv3Q=
+f
+	wsVk0UbtQ1faGnRfEeCS6ICxj5PROYkrzZvAd3CfT4GfHkFXnynlApuqqC+djwaBvbBpx3eXfD=
+q
+	qb3XQ/hue1U/Euj8bPgviCrXu93JNzjSufs2oTAvK4cKjK2vlq8OTZexKs73Ol3wq8bGz2prEk=
+r
+	SbZSQWFUBAqBajX2hg=3D
+X-TMASE-SNAP-Result: 1.821001.0001-0-1-12:0,22:0,33:0,34:0,39:0-0
+X-TM-Deliver-Signature: A1F966477493E8CC077EFBFD2963EE52
+Return-Path: postmaster@ninomail.com
+X-EOPAttributedMessage: 0
+X-EOPTenantAttributedMessage: caef7785-c073-4453-8b47-6432b6b5b10f:0
+X-Forefront-Antispam-Report: CIP:52.58.62.203;IPV:NLI;CTRY:US;EFV:NLI;
+X-Microsoft-Exchange-Diagnostics: 1;HE1EUR01FT040;1:8Yfy3RCcMtWjd2wHETuKGgb=
+YvMhwEmz4LIe9f7oSB4tp7h0z7cACxryH+0M3NT8qJ2/j7nTdwkEifFRCFkEmVm/8U0MfnxdPin=
+eDdDC5D9GGTRKhxkl4L+aROlRj/J3a
+X-MS-PublicTrafficType: Email
+X-MS-Office365-Filtering-Correlation-Id: c68ecd6c-bb49-4ed3-2782-08d5122afa=
+fa
+X-DkimResult-Test: Passed
+X-Microsoft-Antispam:
+	UriScan:;BCL:0;PCL:0;RULEID:(22001)(23075)(421252002)(3001016)(71702078);S=
+RVR:DB5PR06MB1800;
+X-Microsoft-Exchange-Diagnostics:
+	1;DB5PR06MB1800;3:eIUBG2d+QhGEssrKUk0vR7Qo1xBaLzxFYKXinPbtC3lbNOOKl0ptZ6Dw=
+pd5/OvUk0hZRjDmU0H0A+3+cYAwCf+XK0aF+w/f/0BM1HB6RqZvKasYY4skANmQh1SUIE3/Nlmm=
+fNUCPAXe2mYko5gjHS3FWfNfn5JUpUc0uqi1CiQZuz75UkMI1StjnNztymn4Poa04bv329Q323g=
+fsNJDTRWxvCNmrgSBqavZ85LE43+/3tXAXH25lu0HWaLJbf+P7M91/9m1dGEE3lE9BSHAgsW5mx=
+Y0Rgk9Cfi44Cz2zJn1W5JH5LJ2aR7fnETCIBMSnTmU9lskn5OxBoBsug3J1sg=3D=3D;25:QhTo=
+XBW84g8b1E0tDQz1wlgKZHT3MfBBXPqER0vHXiVfl5tgVG8PQ9vjAYKosqQIh25bjvo5I/HrmLe=
+8XFOg6bYQI/VrzqPSE6wBZTZ+nZ8dFdyWwRSbX85RKC9pm62yFaIbsOkta1xF/q8CE5nyFkKfUx=
+Ht9vHosW4IrzT7+w8XAhh0VqhUYOvk4Cp1St3M8L8GAu90Dj3kaupTwZhxUxVkYVewyc8xb74an=
+pZIASat5MjRVcVH26j5EUwN24Ko1RUunp7SXLydpXqJKUJcxjbJe6absxj+5Fb2GzCQh+k/9quB=
+IDXusyO9MsAorZoZMVUVl/pmy/6V/KYy9AfpsAgvXvZoa31ftGl2wTt6t3k=3D
+X-MS-TrafficTypeDiagnostic: DB5PR06MB1800:
+</pre>
+  </body>
+</html>=
+
+--75454191-d3d5-48ec-b8f1-8aa1d75d02e4--
+
+--22a54575-c842-43f3-83ea-721e8360fb4c
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns;DB5PR06MB1800.eurprd06.prod.outlook.com
+Received-From-MTA: dns;ioutemea3.hes.trendmicro.eu
+Arrival-Date: Fri, 13 Oct 2017 11:10:16 +0000
+
+Original-Recipient: rfc822;noname@example.com
+Final-Recipient: rfc822;noname@example.com
+Action: failed
+Status: 5.1.10
+Diagnostic-Code: smtp;550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipient noname@example.com not found by SMTP address lookup
+
+
+--22a54575-c842-43f3-83ea-721e8360fb4c
+Content-Type: message/rfc822
+
+Received: from VI1PR0601CA0032.eurprd06.prod.outlook.com
+ (2603:10a6:800:1e::42) by DB5PR06MB1800.eurprd06.prod.outlook.com
+ (2a01:111:e400:7905::18) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id 15.20.77.7; Fri, 13 Oct
+ 2017 11:10:16 +0000
+Received: from HE1EUR01FT040.eop-EUR01.prod.protection.outlook.com
+ (2a01:111:f400:7e1f::206) by VI1PR0601CA0032.outlook.office365.com
+ (2603:10a6:800:1e::42) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id 15.20.77.7 via Frontend
+ Transport; Fri, 13 Oct 2017 11:10:15 +0000
+Authentication-Results: spf=softfail (sender IP is 52.58.62.203)
+ smtp.mailfrom=ninomail.com; example.com; dkim=pass (signature was
+ verified) header.d=ninomail.com;example.com; dmarc=none action=none
+ header.from=mailgunhq.com;
+Received-SPF: SoftFail (protection.outlook.com: domain of transitioning
+ ninomail.com discourages use of 52.58.62.203 as permitted sender)
+Received: from ioutemea3.hes.trendmicro.eu (52.58.62.203) by
+ HE1EUR01FT040.mail.protection.outlook.com (10.152.1.72) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P384) id
+ 15.20.77.10 via Frontend Transport; Fri, 13 Oct 2017 11:10:14 +0000
+Received: from 209.61.154.103_hes.trendmicro.com (unknown [192.168.13.217])
+	by ioutemea3.hes.trendmicro.eu (Postfix) with SMTP id 749FD11200E
+	for <noname@example.com>; Fri, 13 Oct 2017 11:10:14 +0000 (UTC)
+Received: from dfw-p103.ninomail.com (unknown [209.61.154.103])
+	by inpreemea2.hes.trendmicro.eu (Postfix) with ESMTPS id 2D9022EE05E
+	for <noname@example.com>; Fri, 13 Oct 2017 11:10:13 +0000 (UTC)
+DKIM-Signature: a=rsa-sha256; v=1; c=relaxed/relaxed; d=ninomail.com; q=dns/txt; s=mx;
+ t=1507893012; h=Content-Transfer-Encoding: Mime-Version: Content-Type:
+ Subject: From: To: Message-Id: List-Unsubscribe: Date;
+ bh=Z0RRkWGMZ95HQdCnkNkIEgrcz3FH2ScG0r54JXFR3Vw=; b=ArQ3Q8lB0KCJxNGU0uwQe8mnOWDTlOi+T0lie9zlMs/kk7xgbuJBtt0xfE40o/gIlYENQ5VV
+ yrubfcZ0JTnszpw2QJVLJs/ETig+ZA10qRXR7P+EwzbyCI7XEneMrcwQsBFbrDBHiMVsPCws
+ 6Sppee8wcuTNbWfkdOhbY8xpQ/o=
+DomainKey-Signature: a=rsa-sha1; c=nofws; d=ninomail.com; s=mx; q=dns;
+ h=Date: List-Unsubscribe: Message-Id: To: From: Subject: Content-Type:
+ Mime-Version: Content-Transfer-Encoding;
+ b=keeX65FWYAvnsAB/PT4Bwv5z2gZlber/+lccOi3sEbbWy+dBP58bVTxMju9kTjV5FR8Nix
+ ePnEngG56ziSjkEXiPLI2bIfLYZf0sByiB4giyTlejQW4su2ymBVfIX0pj/P9TT/Hk24ZtPF
+ DFQfd2DXdV+ssayd7A0boyiqyrrOk=
+Date: Fri, 13 Oct 2017 11:10:12 +0000
+X-Mailgun-Sending-Ip: 209.61.154.103
+X-Mailgun-Sid: WyJlYjg3MCIsICJob3JraGVAc3VwZXJvZmZpY2UuY29tIiwgIjYiXQ==
+List-Unsubscribe: <mailto:u+mq6tmjtjhuzdamjxgeydcmzrgeytamjrfyzdaobwgyxdenjuimzemm2bgrcdoqkbguzdmjjugbxgs3tpnvqws3bomnxw2jtihu4gcnjxgjrgmzbtgu2wezrvgazgeolemiydonbvgqzwiyjxmq3dojtshvug64tlnbssknbqon2xazlsn5tgm2ldmuxgg33nez2d2jjsie@ninomail.com>
+Received: by luna.mailgun.net with HTTP; Fri, 13 Oct 2017 11:10:11 +0000
+Message-ID: <20171013111011.20866.254C2F3A4D7AA526@ninomail.com>
+X-Mailgun-Native-Send: yes
+To: noname@example.com
+From: noname@mailgunhq.com
+Subject: test_bounce 8
+Content-Type: text/plain; charset="ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-TM-Received-SPF: Pass (domain of postmaster@ninomail.com designates 
+	209.61.154.103 as permitted sender) client-ip=209.61.154.103; 
+	envelope-from=postmaster@ninomail.com; helo=dfw-p103.ninomail.com
+X-TMASE-Version: StarCloud-1.3-8.2.1006-23392.006
+X-TMASE-Result: 10--2.729200-10.000000
+X-TMASE-MatchedRID: GooOU10L43zav6YmtDxNqNFig1NpvMlDPuK6nXzgR1TnBDF/TMnTXjJl
+	3MhaKU4m4vM1YF6AJbaKoonP3ywz3Y4dBcJ6M5YH0ddkKKNSSi9XH0VVrOHyJe2tcfduZIOv3Qf
+	wsVk0UbtQ1faGnRfEeCS6ICxj5PROYkrzZvAd3CfT4GfHkFXnynlApuqqC+djwaBvbBpx3eXfDq
+	qb3XQ/hue1U/Euj8bPgviCrXu93JNzjSufs2oTAvK4cKjK2vlq8OTZexKs73Ol3wq8bGz2prEkr
+	SbZSQWFUBAqBajX2hg=
+X-TMASE-SNAP-Result: 1.821001.0001-0-1-12:0,22:0,33:0,34:0,39:0-0
+X-TM-Deliver-Signature: A1F966477493E8CC077EFBFD2963EE52
+Return-Path: postmaster@ninomail.com
+X-EOPAttributedMessage: 0
+X-EOPTenantAttributedMessage: caef7785-c073-4453-8b47-6432b6b5b10f:0
+X-Forefront-Antispam-Report: CIP:52.58.62.203;IPV:NLI;CTRY:US;EFV:NLI;
+X-Microsoft-Exchange-Diagnostics: 1;HE1EUR01FT040;1:8Yfy3RCcMtWjd2wHETuKGgbYvMhwEmz4LIe9f7oSB4tp7h0z7cACxryH+0M3NT8qJ2/j7nTdwkEifFRCFkEmVm/8U0MfnxdPineDdDC5D9GGTRKhxkl4L+aROlRj/J3a
+X-MS-PublicTrafficType: Email
+X-MS-Office365-Filtering-Correlation-Id: c68ecd6c-bb49-4ed3-2782-08d5122afafa
+X-DkimResult-Test: Passed
+X-Microsoft-Antispam: UriScan:;BCL:0;PCL:0;RULEID:(22001)(23075)(421252002)(3001016)(71702078);SRVR:DB5PR06MB1800;
+X-Microsoft-Exchange-Diagnostics: 1;DB5PR06MB1800;3:eIUBG2d+QhGEssrKUk0vR7Qo1xBaLzxFYKXinPbtC3lbNOOKl0ptZ6Dwpd5/OvUk0hZRjDmU0H0A+3+cYAwCf+XK0aF+w/f/0BM1HB6RqZvKasYY4skANmQh1SUIE3/NlmmfNUCPAXe2mYko5gjHS3FWfNfn5JUpUc0uqi1CiQZuz75UkMI1StjnNztymn4Poa04bv329Q323gfsNJDTRWxvCNmrgSBqavZ85LE43+/3tXAXH25lu0HWaLJbf+P7M91/9m1dGEE3lE9BSHAgsW5mxY0Rgk9Cfi44Cz2zJn1W5JH5LJ2aR7fnETCIBMSnTmU9lskn5OxBoBsug3J1sg==;25:QhToXBW84g8b1E0tDQz1wlgKZHT3MfBBXPqER0vHXiVfl5tgVG8PQ9vjAYKosqQIh25bjvo5I/HrmLe8XFOg6bYQI/VrzqPSE6wBZTZ+nZ8dFdyWwRSbX85RKC9pm62yFaIbsOkta1xF/q8CE5nyFkKfUxHt9vHosW4IrzT7+w8XAhh0VqhUYOvk4Cp1St3M8L8GAu90Dj3kaupTwZhxUxVkYVewyc8xb74anpZIASat5MjRVcVH26j5EUwN24Ko1RUunp7SXLydpXqJKUJcxjbJe6absxj+5Fb2GzCQh+k/9quBIDXusyO9MsAorZoZMVUVl/pmy/6V/KYy9AfpsAgvXvZoa31ftGl2wTt6t3k=
+X-MS-TrafficTypeDiagnostic: DB5PR06MB1800:
+
+test
+
+
+To unsubscribe click: <http://ninomail.com/u/eJwdy0EOwiAQAMDXlCPZXVi2HjgQjf-AAoFoi0H9v42XuU32TnVPgIKABvEUNcHqnCa2V7qbYG8SApNbLBz9GHvsT72NXTW_RhZKNRvmVBkoXXICsWxNjpKdqOnbmI9Wzvr-vsoctfat_PfHLxR-FEgjhA>
+
+
+--22a54575-c842-43f3-83ea-721e8360fb4c--

--- a/tests/mime/bounce_tests.py
+++ b/tests/mime/bounce_tests.py
@@ -21,5 +21,5 @@ def test_bounce_analyzer_on_regular():
 
 
 def test_bounce_no_headers_error_message():
-    msg = create.from_string("Nothing")
+    msg = create.from_string('Nothing')
     assert_false(msg.is_bounce())

--- a/tests/mime/bounce_tests.py
+++ b/tests/mime/bounce_tests.py
@@ -1,25 +1,64 @@
-from nose.tools import ok_, eq_, assert_false
-from flanker.mime import create
-from tests import BOUNCE, SIGNED
+from nose.tools import eq_
+
+from flanker.mime import create, bounce
+from tests import BOUNCE, SIGNED, BOUNCE_OFFICE365
 
 
-def test_bounce_analyzer_on_bounce():
-    bm = create.from_string(BOUNCE)
-    ok_(bm.is_bounce())
-    eq_('5.1.1', bm.bounce.status)
-    eq_('smtp; 550-5.1.1 The email account that you tried to reach does'
-        '    not exist. Please try 550-5.1.1 double-checking the recipient\'s email'
-        '    address for typos or 550-5.1.1 unnecessary spaces. Learn more at'
-        '    550 5.1.1 http://mail.google.com/support/bin/answer.py?answer=6596'
-        '    17si20661415yxe.22',
-        bm.bounce.diagnostic_code)
+def test_bounce_detect():
+    for i, tc in enumerate([{
+        'desc': 'Common bounce example',
+        'mime': create.from_string(BOUNCE),
+        'result': bounce.Result(
+            score=1.875,
+            status=u'5.1.1',
+            notification=(
+                    u"This is the mail system at host mail.example.com.\n\n"
+                    u"I'm sorry to have to inform you that your message could not\n"
+                    u"be delivered to one or more recipients. It's attached below.\n\n"
+                    u"For further assistance, please send mail to postmaster.\n\n"
+                    u"If you do so, please include this problem report. You can\n"
+                    u"delete your own text from the attached returned message.\n\n"
+                    u"                   The mail system\n\n"
+                    u"<asdfasdfasdfasdfasdfasdfewrqertrtyrthsfgdfgadfqeadvxzvz@gmail.com>: host\n"
+                    u"    gmail-smtp-in.l.google.com[209.85.210.17] said: 550-5.1.1 The email account\n"
+                    u"    that you tried to reach does not exist. Please try 550-5.1.1\n"
+                    u"    double-checking the recipient's email address for typos or 550-5.1.1\n"
+                    u"    unnecessary spaces. Learn more at                              550 5.1.1\n"
+                    u"    http://mail.google.com/support/bin/answer.py?answer=6596 17si20661415yxe.22\n"
+                    u"    (in reply to RCPT TO command)\n"),
+            diagnostic_code=(
+                    u"smtp; 550-5.1.1 The email account that you tried to reach does"
+                    u"    not exist. Please try 550-5.1.1 double-checking the recipient's email"
+                    u"    address for typos or 550-5.1.1 unnecessary spaces. Learn more at"
+                    u"    550 5.1.1 http://mail.google.com/support/bin/answer.py?answer=6596"
+                    u"    17si20661415yxe.22")),
+        'is_bounce': True
+    }, {
+        'desc': 'Office365 bounce messages lack Content-Description',
+        'mime': create.from_string(BOUNCE_OFFICE365),
+        'result': bounce.Result(
+            score=1.25,
+            status=u'5.1.10',
+            notification=u'',
+            diagnostic_code=(
+                    u'smtp;550 5.1.10 RESOLVER.ADR.RecipientNotFound; '
+                    u'Recipient noname@example.com not found by SMTP address lookup')),
+        'is_bounce': True
+    }, {
+        'desc': 'Regular message',
+        'mime': create.from_string(SIGNED),
+        'result': bounce.Result(
+            score=0.0,
+            status=u'',
+            notification=u'',
+            diagnostic_code=u''),
+        'is_bounce': False
+    }]):
+        print('Test case #%d: %s' % (i, tc['desc']))
 
+        # When
+        result = bounce.detect(tc['mime'])
 
-def test_bounce_analyzer_on_regular():
-    bm = create.from_string(SIGNED)
-    assert_false(bm.is_bounce())
-
-
-def test_bounce_no_headers_error_message():
-    msg = create.from_string('Nothing')
-    assert_false(msg.is_bounce())
+        # Then
+        eq_(result, tc['result'])
+        eq_(result.is_bounce(), tc['is_bounce'])

--- a/tests/mime/message/headers/encodedword_test.py
+++ b/tests/mime/message/headers/encodedword_test.py
@@ -8,7 +8,7 @@ from flanker.mime.message import errors, charsets
 
 def encoded_word_test():
     def t(value):
-        m  = encodedword.encodedWord.match(value)
+        m  = encodedword._RE_ENCODED_WORD.match(value)
         return (m.group('charset'), m.group('encoding'), m.group('encoded'))
 
     r = t('=?utf-8?B?U2ltcGxlIHRleHQuIEhvdyBhcmUgeW91PyDQmtCw0Log0YLRiyDQv9C+0LY=?=')
@@ -128,17 +128,21 @@ def various_encodings_test():
     v = '=?UTF-8?B?0J/RgNC+0LLQtdGA0Y/QtdC8INGA0YPRgdGB0LrQuNC1INGB0LDQsdC2?=\r\n =?UTF-8?B?0LXQutGC0Ysg0Lgg0Y7QvdC40LrQvtC0IOKYoA==?='
     eq_(u'Проверяем русские сабжекты и юникод ☠', encodedword.mime_to_unicode(v))
 
-    v = u'=?utf-8?Q?Evaneos-Concepci=C3=B3n.pdf?='
+    v = '=?utf-8?Q?Evaneos-Concepci=C3=B3n.pdf?='
     eq_(u'Evaneos-Concepción.pdf', encodedword.mime_to_unicode(v))
 
 
 @patch.object(utils, '_guess_and_convert', Mock(side_effect=errors.EncodingError()))
 def test_convert_to_utf8_unknown_encoding():
-    v = "abc\x80def"
-    eq_(u"abc\u20acdef", charsets.convert_to_unicode("windows-874", v))
-    eq_(u"qwe", charsets.convert_to_unicode('X-UNKNOWN', u"qwe"))
-    eq_(u"qwe", charsets.convert_to_unicode('ru_RU.KOI8-R', 'qwe'))
-    eq_(u"qwe", charsets.convert_to_unicode('"utf-8"; format="flowed"', 'qwe'))
+    eq_(u"abc\u20acdef",
+        charsets.convert_to_unicode("windows-874", b"abc\x80def"))
+    eq_(u"qwe",
+        charsets.convert_to_unicode('X-UNKNOWN', u'qwe'))
+    eq_(u"qwe",
+        charsets.convert_to_unicode('ru_RU.KOI8-R', 'qwe'))
+    eq_(u"qwe",
+        charsets.convert_to_unicode('"utf-8"; format="flowed"', 'qwe'))
+
 
 @patch.object(encodedword, 'unfold', Mock(side_effect=Exception))
 def test_error_reporting():

--- a/tests/mime/message/headers/encoding_test.py
+++ b/tests/mime/message/headers/encoding_test.py
@@ -6,7 +6,7 @@ from nose.tools import eq_, ok_
 from mock import patch, Mock
 
 from flanker.mime.message import headers
-from flanker.mime.message.headers.encoding import (encode_unstructured,
+from flanker.mime.message.headers.encoding import (_encode_unstructured,
                                                    encode_string)
 from flanker.mime.message import part
 from flanker.mime import create
@@ -63,24 +63,25 @@ def max_header_length_test():
     ascii_subject = "This is simple ascii subject"
 
     with patch.object(
-        headers.encoding, 'MAX_HEADER_LENGTH', len(ascii_subject) + 1):
+        headers.encoding, '_MAX_HEADER_LENGTH', len(ascii_subject) + 1):
 
         eq_(Header(ascii_subject.encode("ascii"), "ascii", header_name="Subject"),
-            encode_unstructured("Subject", ascii_subject))
+            _encode_unstructured("Subject", ascii_subject))
 
     with patch.object(
-        headers.encoding, 'MAX_HEADER_LENGTH', len(unicode_subject) + 1):
+        headers.encoding, '_MAX_HEADER_LENGTH', len(unicode_subject) + 1):
 
         eq_(Header(unicode_subject.encode("utf-8"), "utf-8", header_name="Subject"),
-            encode_unstructured("Subject", unicode_subject))
+            _encode_unstructured("Subject", unicode_subject))
 
-    with patch.object(headers.encoding, 'MAX_HEADER_LENGTH', 1):
+    with patch.object(headers.encoding, '_MAX_HEADER_LENGTH', 1):
 
         eq_(ascii_subject.encode("utf-8"),
-            encode_unstructured("Subject", ascii_subject))
+            _encode_unstructured("Subject", ascii_subject))
 
         eq_(unicode_subject.encode("utf-8"),
-            encode_unstructured("Subject", unicode_subject))
+            _encode_unstructured("Subject", unicode_subject))
+
 
 def add_header_preserve_original_encoding_test():
     message = create.from_string(ENCODED_HEADER)

--- a/tests/mime/message/tokenizer_test.py
+++ b/tests/mime/message/tokenizer_test.py
@@ -1,5 +1,4 @@
 # coding:utf-8
-import zlib
 from nose.tools import eq_
 
 from flanker.mime.message.scanner import tokenize, ContentType, Boundary
@@ -13,216 +12,200 @@ B = Boundary
 
 
 def tokenizer_table_driven_test():
-    cases = [
-        (
-            'Nothing',
-            'We are ok, when there is no content type and boundaries',
-            NO_CTYPE,
-            []
-        ), (
-            'Binary',
-            'Can scan binary stuff: works for 8bit mime',
-            EIGHT_BIT,
-            [
-                C('multipart', 'alternative', dict(boundary="=-omjqkVTVbwdgCWFRgIkx")),
-                B("=-omjqkVTVbwdgCWFRgIkx", _DUMMY, _DUMMY, False),
-                C('text', 'plain', dict(charset="UTF-8")),
-                B("=-omjqkVTVbwdgCWFRgIkx", _DUMMY, _DUMMY, False),
-                C('text', 'html', dict(charset="utf-8")),
-                B("=-omjqkVTVbwdgCWFRgIkx", _DUMMY, _DUMMY, True)
-            ]
-        ), (
-            'Dashes',
-            'Boundary can contain `--`',
-            BIG,
-            [
-                C('multipart', 'mixed', dict(boundary="------------060808020401090407070006")),
-                B("------------060808020401090407070006", _DUMMY, _DUMMY, False),
-                C('text', 'html', dict(charset="ISO-8859-1")),
-                B("------------060808020401090407070006", _DUMMY, _DUMMY, False),
-                C('image', 'tiff', dict(name="teplosaurus-hi-res-02.tif")),
-                B("------------060808020401090407070006", _DUMMY, _DUMMY, True)
-            ]
-        ), (
-            'Dashes 2',
-            'Boundary can contain `--` at the end, even on boundaries other then the last one',
-            DASHED_BOUNDARIES,
-            [
-                C('multipart', 'alternative', dict(boundary="--120710081418BV.24190.Texte--")),
-                B("--120710081418BV.24190.Texte--", _DUMMY, _DUMMY, False),
-                C('text', 'plain', dict(charset="UTF-8")),
-                B("--120710081418BV.24190.Texte--", _DUMMY, _DUMMY, False),
-                C('text', 'html', dict(charset="UTF-8")),
-                B("--120710081418BV.24190.Texte--", _DUMMY, _DUMMY, True)
-            ]
-        ), (
-            'Enclosed',
-            'Enclosed RFC-822 messages are properly identified',
-            ENCLOSED,
-            [
-                C('multipart', 'mixed', {'boundary': u'===============6195527458677812340=='}),
-                B('===============6195527458677812340==', 2567, 2608, final=False),
-                C('text', 'plain', {'charset': u'us-ascii', 'format': u'flowed'}),
-                B('===============6195527458677812340==', 2733, 2774, final=False),
-                C('message', 'rfc822', {'name': u'thanks.eml'}),
-                C('multipart', 'alternative', {'boundary': u'===============4360815924781479146=='}),
-                B('===============4360815924781479146==', 3792, 3833, final=False),
-                C('text', 'plain', {'charset': u'utf-8'}),
-                B('===============4360815924781479146==', 4323, 4364, final=False),
-                C('text', 'html', {'charset': u'utf-8'}),
-                B('===============4360815924781479146==', 5305, 5348, final=True),
-                B('===============6195527458677812340==', 5347, 5390, final=True)
-            ]
-        ), (
-            'Headers',
-            'Content-Type from rfc822-headers part is retrieved',
-            NOTIFICATION,
-            [
-                C('multipart', 'report', {'boundary': u'CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 'report-type': u'delivery-status'}),
-                B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 407, 450, final=False),
-                C('text', 'plain', {}),
-                B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 1090, 1133, final=False),
-                C('message', 'delivery-status', {}),
-                B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 1478, 1521, final=False),
-                C('text', 'rfc822-headers', {}),
-                C('multipart', 'alternative', {'boundary': u'----=_NextPart_000_0000_01CD5B2E.428C0BF0'}),
-                B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 2076, 2121, final=True)
-            ]
-        ), (
-            'Huge',
-            'Stress test',
-            TORTURE,
-            [
-                C('multipart', 'mixed', {'boundary': u'owatagusiam'}),
-                B('owatagusiam', 389, 403, final=False),
-                C('text', 'plain', {}),
-                B('owatagusiam', 650, 664, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'alternative', {'boundary': u'Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk='}),
-                B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 2438, 2496, final=False),
-                B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 3249, 3307, final=False),
-                C('multipart', 'mixed', {'boundary': u'Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2Yt1KaFdA'}),
-                B('Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2Yt1KaFdA', 3410, 3470, final=False),
-                C('text', 'richtext', {}),
-                B('Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2Yt1KaFdA', 4418, 4480, final=True),
-                B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 4481, 4539, final=False),
-                C('application', 'andrew-inset', {}),
-                B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 5470, 5530, final=True),
-                B('owatagusiam', 5531, 5545, final=False),
-                C('message', 'rfc822', {}),
-                C('audio', 'basic', {}),
-                B('owatagusiam', 560278, 560292, final=False),
-                C('audio', 'basic', {}),
-                B('owatagusiam', 596156, 596170, final=False),
-                C('image', 'pbm', {}),
-                B('owatagusiam', 598054, 598068, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'mixed', {'boundary': u'Outermost_Trek'}),
-                B('Outermost_Trek', 599955, 599972, final=False),
-                C('multipart', 'mixed', {'boundary': u'Where_No_One_Has_Gone_Before'}),
-                B('Where_No_One_Has_Gone_Before', 600041, 600072, final=False),
-                B('Where_No_One_Has_Gone_Before', 600789, 600820, final=False),
-                C('audio', 'x-sun', {}),
-                B('Where_No_One_Has_Gone_Before', 631964, 631997, final=True),
-                B('Outermost_Trek', 631997, 632014, final=False),
-                C('multipart', 'mixed', {'boundary': u'Where_No_Man_Has_Gone_Before'}),
-                B('Where_No_Man_Has_Gone_Before', 632083, 632114, final=False),
-                C('image', 'gif', {}),
-                B('Where_No_Man_Has_Gone_Before', 657860, 657891, final=False),
-                C('image', 'gif', {}),
-                B('Where_No_Man_Has_Gone_Before', 676411, 676442, final=False),
-                C('application', 'x-be2', {'version': u'12'}),
-                B('Where_No_Man_Has_Gone_Before', 720176, 720207, final=False),
-                C('application', 'atomicmail', {'version': u'1.12'}),
-                B('Where_No_Man_Has_Gone_Before', 729107, 729140, final=True),
-                B('Outermost_Trek', 729140, 729157, final=False),
-                C('audio', 'x-sun', {}),
-                B('Outermost_Trek', 776430, 776449, final=True),
-                B('owatagusiam', 776451, 776465, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'mixed', {'boundary': u'mail.sleepy.sau.144.8891'}),
-                B('mail.sleepy.sau.144.8891', 777837, 777864, final=False),
-                B('mail.sleepy.sau.144.8891', 777887, 777914, final=False),
-                C('image', 'pgm', {}),
-                B('mail.sleepy.sau.144.8891', 861843, 861870, final=False),
-                B('mail.sleepy.sau.144.8891', 862131, 862160, final=True),
-                B('owatagusiam', 862162, 862176, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'mixed', {'boundary': u'mail.sleepy.sau.158.532'}),
-                B('mail.sleepy.sau.158.532', 863503, 863529, final=False),
-                B('mail.sleepy.sau.158.532', 864751, 864777, final=False),
-                C('image', 'pbm', {}),
-                B('mail.sleepy.sau.158.532', 936251, 936279, final=True),
-                B('owatagusiam', 936280, 936294, final=False),
-                C('message', 'rfc822', {}),
-                C('application', 'postscript', {}),
-                B('owatagusiam', 1327932, 1327946, final=False),
-                C('image', 'gif', {}),
-                B('owatagusiam', 1405346, 1405360, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'mixed', {'boundary': u'hal_9000'}),
-                B('hal_9000', 1406105, 1406116, final=False),
-                C('audio', 'basic', {}),
-                B('hal_9000', 1467518, 1467529, final=False),
-                C('audio', 'basic', {}),
-                B('hal_9000', 1507722, 1507735, final=True),
-                B('owatagusiam', 1507735, 1507749, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'mixed', {'boundary': u'16819560-2078917053-688350843:#11603'}),
-                B('16819560-2078917053-688350843:#11603', 1508361, 1508400, final=False),
-                C('application', 'postscript', {}),
-                B('16819560-2078917053-688350843:#11603', 1560994, 1561033, final=False),
-                C('application', 'octet-stream', {'name': u'Alices_PDP-10'}),
-                B('16819560-2078917053-688350843:#11603', 1579392, 1579431, final=False),
-                C('message', 'rfc822', {}),
-                C('multipart', 'mixed', {'boundary': u'foobarbazola'}),
-                B('foobarbazola', 1579725, 1579740, final=False),
-                B('foobarbazola', 1580054, 1580069, final=False),
-                C('multipart', 'parallel', {'boundary': u'seconddivider'}),
-                B('seconddivider', 1580126, 1580142, final=False),
-                C('image', 'gif', {}),
-                B('seconddivider', 1583489, 1583505, final=False),
-                C('audio', 'basic', {}),
-                B('seconddivider', 1739502, 1739520, final=True),
-                B('foobarbazola', 1739552, 1739567, final=False),
-                C('application', 'atomicmail', {}),
-                B('foobarbazola', 1744335, 1744350, final=False),
-                C('message', 'rfc822', {}),
-                C('audio', 'x-sun', {}),
-                B('foobarbazola', 1819319, 1819336, final=True),
-                B('16819560-2078917053-688350843:#11603', 1819336, 1819377, final=True),
-                B('owatagusiam', 1819377, 1819393, final=True)
-            ]
-        ), (
-            'Garbage',
-            'We survive complete garbage input',
-            zlib.compress(NO_CTYPE),
-            []
-        ), (
-            'Ignored',
-            'Content-Type headers in the multipart preamble and epilogue are ignored',
-            ATTACHED_PDF,
-            [C('multipart', 'mixed', {'boundary': u'_001_538f5bb0a7956_457a8046c758764ef_'}),
-             B('_001_538f5bb0a7956_457a8046c758764ef_', 198, 238, final=False),
-             C('multipart', 'alternative', {'boundary': u'_000_538f5bb0a7956_457a8046c758764ef_'}),
-             B('_000_538f5bb0a7956_457a8046c758764ef_', 479, 519, final=False),
-             C('text', 'plain', {}),
-             B('_000_538f5bb0a7956_457a8046c758764ef_', 567, 609, final=True),
-             B('_001_538f5bb0a7956_457a8046c758764ef_', 685, 725, final=False),
-             C('application', 'pdf', {'name': u'test.pdf'}),
-             B('_001_538f5bb0a7956_457a8046c758764ef_', 10239, 10281, final=True)]
-        )
-    ]
+    for i, tc in enumerate([{
+        'desc': 'We are ok, when there is no content type and boundaries',
+        'mime': NO_CTYPE,
+        'tokens': []
+    }, {
+        'desc': 'Can scan binary stuff: works for 8bit mime',
+        'mime': EIGHT_BIT,
+        'tokens': [
+            C('multipart', 'alternative', dict(boundary="=-omjqkVTVbwdgCWFRgIkx")),
+            B("=-omjqkVTVbwdgCWFRgIkx", _DUMMY, _DUMMY, False),
+            C('text', 'plain', dict(charset="UTF-8")),
+            B("=-omjqkVTVbwdgCWFRgIkx", _DUMMY, _DUMMY, False),
+            C('text', 'html', dict(charset="utf-8")),
+            B("=-omjqkVTVbwdgCWFRgIkx", _DUMMY, _DUMMY, True)
+        ]
+    }, {
+        'desc': 'Boundary can contain `--`',
+        'mime': BIG,
+        'tokens': [
+            C('multipart', 'mixed', dict(boundary="------------060808020401090407070006")),
+            B("------------060808020401090407070006", _DUMMY, _DUMMY, False),
+            C('text', 'html', dict(charset="ISO-8859-1")),
+            B("------------060808020401090407070006", _DUMMY, _DUMMY, False),
+            C('image', 'tiff', dict(name="teplosaurus-hi-res-02.tif")),
+            B("------------060808020401090407070006", _DUMMY, _DUMMY, True)
+        ]
+    }, {
+        'desc': 'Boundary can contain `--` at the end, even on boundaries other then the last one',
+        'mime': DASHED_BOUNDARIES,
+        'tokens': [
+            C('multipart', 'alternative', dict(boundary="--120710081418BV.24190.Texte--")),
+            B("--120710081418BV.24190.Texte--", _DUMMY, _DUMMY, False),
+            C('text', 'plain', dict(charset="UTF-8")),
+            B("--120710081418BV.24190.Texte--", _DUMMY, _DUMMY, False),
+            C('text', 'html', dict(charset="UTF-8")),
+            B("--120710081418BV.24190.Texte--", _DUMMY, _DUMMY, True)
+        ]
+    }, {
+        'desc': 'Enclosed RFC-822 messages are properly identified',
+        'mime': ENCLOSED,
+        'tokens': [
+            C('multipart', 'mixed', {'boundary': '===============6195527458677812340=='}),
+            B('===============6195527458677812340==', 2567, 2608, final=False),
+            C('text', 'plain', {'charset': 'us-ascii', 'format': 'flowed'}),
+            B('===============6195527458677812340==', 2733, 2774, final=False),
+            C('message', 'rfc822', {'name': 'thanks.eml'}),
+            C('multipart', 'alternative', {'boundary': '===============4360815924781479146=='}),
+            B('===============4360815924781479146==', 3792, 3833, final=False),
+            C('text', 'plain', {'charset': 'utf-8'}),
+            B('===============4360815924781479146==', 4323, 4364, final=False),
+            C('text', 'html', {'charset': 'utf-8'}),
+            B('===============4360815924781479146==', 5305, 5348, final=True),
+            B('===============6195527458677812340==', 5347, 5390, final=True)
+        ]
+    }, {
+        'desc': 'Content-Type from rfc822-headers part is retrieved',
+        'mime': NOTIFICATION,
+        'tokens': [
+            C('multipart', 'report', {'boundary': 'CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 'report-type': 'delivery-status'}),
+            B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 407, 450, final=False),
+            C('text', 'plain', {}),
+            B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 1090, 1133, final=False),
+            C('message', 'delivery-status', {}),
+            B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 1478, 1521, final=False),
+            C('text', 'rfc822-headers', {}),
+            C('multipart', 'alternative', {'boundary': '----=_NextPart_000_0000_01CD5B2E.428C0BF0'}),
+            B('CZz3eIzDbSJYu8fvbSlLFdH+/NwoCMV866Y+Iw==', 2076, 2121, final=True)
+        ]
+    }, {
+        'desc': 'Stress test',
+        'mime': TORTURE,
+        'tokens': [
+            C('multipart', 'mixed', {'boundary': 'owatagusiam'}),
+            B('owatagusiam', 389, 403, final=False),
+            C('text', 'plain', {}),
+            B('owatagusiam', 650, 664, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'alternative', {'boundary': 'Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk='}),
+            B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 2438, 2496, final=False),
+            B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 3249, 3307, final=False),
+            C('multipart', 'mixed', {'boundary': 'Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2Yt1KaFdA'}),
+            B('Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2Yt1KaFdA', 3410, 3470, final=False),
+            C('text', 'richtext', {}),
+            B('Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2Yt1KaFdA', 4418, 4480, final=True),
+            B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 4481, 4539, final=False),
+            C('application', 'andrew-inset', {}),
+            B('Interpart_Boundary_AdJn:mu0M2YtJKaFh9AdJn:mu0M2YtJKaFk=', 5470, 5530, final=True),
+            B('owatagusiam', 5531, 5545, final=False),
+            C('message', 'rfc822', {}),
+            C('audio', 'basic', {}),
+            B('owatagusiam', 560278, 560292, final=False),
+            C('audio', 'basic', {}),
+            B('owatagusiam', 596156, 596170, final=False),
+            C('image', 'pbm', {}),
+            B('owatagusiam', 598054, 598068, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'mixed', {'boundary': 'Outermost_Trek'}),
+            B('Outermost_Trek', 599955, 599972, final=False),
+            C('multipart', 'mixed', {'boundary': 'Where_No_One_Has_Gone_Before'}),
+            B('Where_No_One_Has_Gone_Before', 600041, 600072, final=False),
+            B('Where_No_One_Has_Gone_Before', 600789, 600820, final=False),
+            C('audio', 'x-sun', {}),
+            B('Where_No_One_Has_Gone_Before', 631964, 631997, final=True),
+            B('Outermost_Trek', 631997, 632014, final=False),
+            C('multipart', 'mixed', {'boundary': 'Where_No_Man_Has_Gone_Before'}),
+            B('Where_No_Man_Has_Gone_Before', 632083, 632114, final=False),
+            C('image', 'gif', {}),
+            B('Where_No_Man_Has_Gone_Before', 657860, 657891, final=False),
+            C('image', 'gif', {}),
+            B('Where_No_Man_Has_Gone_Before', 676411, 676442, final=False),
+            C('application', 'x-be2', {'version': '12'}),
+            B('Where_No_Man_Has_Gone_Before', 720176, 720207, final=False),
+            C('application', 'atomicmail', {'version': '1.12'}),
+            B('Where_No_Man_Has_Gone_Before', 729107, 729140, final=True),
+            B('Outermost_Trek', 729140, 729157, final=False),
+            C('audio', 'x-sun', {}),
+            B('Outermost_Trek', 776430, 776449, final=True),
+            B('owatagusiam', 776451, 776465, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'mixed', {'boundary': 'mail.sleepy.sau.144.8891'}),
+            B('mail.sleepy.sau.144.8891', 777837, 777864, final=False),
+            B('mail.sleepy.sau.144.8891', 777887, 777914, final=False),
+            C('image', 'pgm', {}),
+            B('mail.sleepy.sau.144.8891', 861843, 861870, final=False),
+            B('mail.sleepy.sau.144.8891', 862131, 862160, final=True),
+            B('owatagusiam', 862162, 862176, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'mixed', {'boundary': 'mail.sleepy.sau.158.532'}),
+            B('mail.sleepy.sau.158.532', 863503, 863529, final=False),
+            B('mail.sleepy.sau.158.532', 864751, 864777, final=False),
+            C('image', 'pbm', {}),
+            B('mail.sleepy.sau.158.532', 936251, 936279, final=True),
+            B('owatagusiam', 936280, 936294, final=False),
+            C('message', 'rfc822', {}),
+            C('application', 'postscript', {}),
+            B('owatagusiam', 1327932, 1327946, final=False),
+            C('image', 'gif', {}),
+            B('owatagusiam', 1405346, 1405360, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'mixed', {'boundary': 'hal_9000'}),
+            B('hal_9000', 1406105, 1406116, final=False),
+            C('audio', 'basic', {}),
+            B('hal_9000', 1467518, 1467529, final=False),
+            C('audio', 'basic', {}),
+            B('hal_9000', 1507722, 1507735, final=True),
+            B('owatagusiam', 1507735, 1507749, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'mixed', {'boundary': '16819560-2078917053-688350843:#11603'}),
+            B('16819560-2078917053-688350843:#11603', 1508361, 1508400, final=False),
+            C('application', 'postscript', {}),
+            B('16819560-2078917053-688350843:#11603', 1560994, 1561033, final=False),
+            C('application', 'octet-stream', {'name': 'Alices_PDP-10'}),
+            B('16819560-2078917053-688350843:#11603', 1579392, 1579431, final=False),
+            C('message', 'rfc822', {}),
+            C('multipart', 'mixed', {'boundary': 'foobarbazola'}),
+            B('foobarbazola', 1579725, 1579740, final=False),
+            B('foobarbazola', 1580054, 1580069, final=False),
+            C('multipart', 'parallel', {'boundary': 'seconddivider'}),
+            B('seconddivider', 1580126, 1580142, final=False),
+            C('image', 'gif', {}),
+            B('seconddivider', 1583489, 1583505, final=False),
+            C('audio', 'basic', {}),
+            B('seconddivider', 1739502, 1739520, final=True),
+            B('foobarbazola', 1739552, 1739567, final=False),
+            C('application', 'atomicmail', {}),
+            B('foobarbazola', 1744335, 1744350, final=False),
+            C('message', 'rfc822', {}),
+            C('audio', 'x-sun', {}),
+            B('foobarbazola', 1819319, 1819336, final=True),
+            B('16819560-2078917053-688350843:#11603', 1819336, 1819377, final=True),
+            B('owatagusiam', 1819377, 1819393, final=True)
+        ]
+    }, {
+        'desc': 'Content-Type headers in the multipart preamble and epilogue are ignored',
+        'mime': ATTACHED_PDF,
+        'tokens': [
+            C('multipart', 'mixed', {'boundary': '_001_538f5bb0a7956_457a8046c758764ef_'}),
+            B('_001_538f5bb0a7956_457a8046c758764ef_', 198, 238, final=False),
+            C('multipart', 'alternative', {'boundary': '_000_538f5bb0a7956_457a8046c758764ef_'}),
+            B('_000_538f5bb0a7956_457a8046c758764ef_', 479, 519, final=False),
+            C('text', 'plain', {}),
+            B('_000_538f5bb0a7956_457a8046c758764ef_', 567, 609, final=True),
+            B('_001_538f5bb0a7956_457a8046c758764ef_', 685, 725, final=False),
+            C('application', 'pdf', {'name': 'test.pdf'}),
+            B('_001_538f5bb0a7956_457a8046c758764ef_', 10239, 10281, final=True)]
+    }]):
+        print('Test case #%d: %s' % (i, tc['desc']))
 
-    for test_name, description, mime_str, expected_tokens in cases:
         # When
-        tokens = tokenize(mime_str)
+        tokens = tokenize(tc['mime'])
 
         # Then
-        max_len = max(len(expected_tokens), len(tokens))
+        max_len = max(len(tc['tokens']), len(tokens))
         for expected_token, token in zip(
-                expected_tokens + [''] * (max_len - len(expected_tokens)),
+                tc['tokens'] + [''] * (max_len - len(tc['tokens'])),
                 tokens + [''] * (max_len - len(tokens))):
-            eq_(expected_token, token,
-                ('\nInvalid token, {}: {}\nexpected={!r}\nactual  ={!r}'
-                 .format(test_name, description, expected_token, token)))
+            eq_(expected_token, token)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py36
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy
+envlist = py27, py35, py36
 
 [testenv]
-commands = nosetests
+deps =
+    nose
+    mock
+commands = nosetests tests/mime/bounce_tests.py


### PR DESCRIPTION
Turns out Office365 bounce message lack `Content-Description` header, but `Diagnostic-Code` should be more than enough.

With this PR I start a practice to make the changed code work under Python 3. In fact the majority of changes were made just to make the bounce test run under Python 3, rather than to fix the actual problem. All Python 3 compatible logic is now tested with Travis CI against both python versions (see build.sh for the list of tests run under Python 3). 

Making MIME scanner Python 3 I made it so that in both python versions it operates on `str` type, but the semantic of the type as you know is different. So under Python 2 the parser works on binary data, but in Python 3 on text data. It was easier that way. The main hindrance in making entire MIME parser Python 3 compatible is `addresslib` module that is used here and there.