### PR TITLE
Make addresslib Python 3 compatible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ if [[ ${TRAVIS_PYTHON_VERSION} == 2.7* ]]; then
     nosetests --with-coverage --cover-package=flanker
 else
     nosetests --with-coverage --cover-package=flanker \
+        tests/addresslib \
         tests/mime/bounce_tests.py \
         tests/mime/message/threading_test.py \
         tests/mime/message/tokenizer_test.py \

--- a/flanker/addresslib/lexer.py
+++ b/flanker/addresslib/lexer.py
@@ -1,6 +1,8 @@
 import ply.lex as lex
 import logging
 
+import six
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
@@ -48,126 +50,109 @@ t_LANGLE    = r'\<'                    # '<'
 t_RANGLE    = r'\>'                    # '>'
 t_SEMICOLON = r'\;'                    # ';'
 
+if six.PY2:
+    _UTF8_2 = r'[\xC2-\xDF][\x80-\xBF]'
+    _UTF8_3 = (r'(\xE0[\xA0-\xBF][\x80-\xBF]'    
+               r'|[\xE1-\xEC][\x80-\xBF]{2}'
+               r'|\xED[\x80-\x9F][\x80-\xBF]'
+               r'|[\xEE-\xEF][\x80-\xBF]{2}'
+               r')')
+
+    _UTF8_4 = (r'(\xF0[\x90-\xBF][\x80-\xBF]{2}'
+    
+               r'|[\xF1-\xF3][\x80-\xBF]{3}'
+               r'|\xF4[\x80-\x8F][\x80-\xBF]{2}'
+               r')')
+else:
+    _UTF8_2 = r'[\u0080-\u07ff]'
+    _UTF8_3 = (r'([\u0800-\u0fff]'
+               r'|[\u1000-\ucfff]'
+               r'|[\ud000-\ud7ff]'
+               r'|[\ue000-\uffff]'
+               r')')
+    _UTF8_4 = (r'([\U00010000-\U0003ffff]'
+               r'|[\U00040000-\U000fffff]'
+               r'|[\U00100000-\U0010ffff]'
+               r')')
+
+_UNICODE_CHAR = '({}|{}|{})'.format(_UTF8_2, _UTF8_3, _UTF8_4)
+
+
+t_ATOM = r'''
+    ( [a-zA-Z0-9!#$%&\'*+\-/=?^_`{{|}}~]  # Visible ASCII except (),.:;<>@[\]
+    | {unicode_char}
+    )+
+'''.format(unicode_char=_UNICODE_CHAR)
+
 # NOTE: Our expression for dot_atom here differs from RFC 5322. In the RFC
 # dot_atom is expressed as a superset of atom. That makes it difficult to write
 # unambiguous parsing rules so we've defined it here in such a way that it
 # doesn't conflict. As a result, any rules that accept dot_atom should also
 # accept atom.
-t_DOT_ATOM = r'''
-             ( [a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~] # Visable ASCII characters not including specials
-             | [\xC2-\xDF][\x80-\xBF]                            # UTF8-2
-             | \xE0[\xA0-\xBF][\x80-\xBF]                        # UTF8-3
-             | [\xE1-\xEC][\x80-\xBF]{2}
-             | \xED[\x80-\x9F][\x80-\xBF]
-             | [\xEE-\xEF][\x80-\xBF]{2}
-             | \xF0[\x90-\xBF][\x80-\xBF]{2}                     # UTF8-4
-             | [\xF1-\xF3][\x80-\xBF]{3}
-             | \xF4[\x80-\x8F][\x80-\xBF]{2}
-             )+
-             (
-             \.
-             ( [a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~] # Visable ASCII characters not including specials
-             | [\xC2-\xDF][\x80-\xBF]                            # UTF8-2
-             | \xE0[\xA0-\xBF][\x80-\xBF]                        # UTF8-3
-             | [\xE1-\xEC][\x80-\xBF]{2}
-             | \xED[\x80-\x9F][\x80-\xBF]
-             | [\xEE-\xEF][\x80-\xBF]{2}
-             | \xF0[\x90-\xBF][\x80-\xBF]{2}                     # UTF8-4
-             | [\xF1-\xF3][\x80-\xBF]{3}
-             | \xF4[\x80-\x8F][\x80-\xBF]{2}
-             )+
-             )+
-             '''
+t_DOT_ATOM = r'{atom}(\.{atom})+'.format(atom=t_ATOM)
 
-t_ATOM =     r'''
-             ( [a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~] # Visable ASCII characters not including specials
-             | [\xC2-\xDF][\x80-\xBF]                            # UTF8-2
-             | \xE0[\xA0-\xBF][\x80-\xBF]                        # UTF8-3
-             | [\xE1-\xEC][\x80-\xBF]{2}
-             | \xED[\x80-\x9F][\x80-\xBF]
-             | [\xEE-\xEF][\x80-\xBF]{2}
-             | \xF0[\x90-\xBF][\x80-\xBF]{2}                     # UTF8-4
-             | [\xF1-\xF3][\x80-\xBF]{3}
-             | \xF4[\x80-\x8F][\x80-\xBF]{2}
-             )+
-             '''
 
 def t_error(t):
     log.warning("syntax error in default lexer, token=%s", t)
 
 # Domain literals - https://tools.ietf.org/html/rfc5322#section-3.4.1
 
+
 def t_LBRACKET(t):
     r'\['
     t.lexer.begin('domain')
     return t
+
 
 def t_domain_RBRACKET(t):
     r'\]'
     t.lexer.begin('INITIAL')
     return t
 
+
 t_domain_DTEXT = r'''
-                 ( [\x21-\x5A]                   # Visable ASCII characters not
-                 | [\x5E-\x7E]                   #   including '[', ']', or '\'
-                 | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
-                 | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
-                 | [\xE1-\xEC][\x80-\xBF]{2}
-                 | \xED[\x80-\x9F][\x80-\xBF]
-                 | [\xEE-\xEF][\x80-\xBF]{2}
-                 | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
-                 | [\xF1-\xF3][\x80-\xBF]{3}
-                 | \xF4[\x80-\x8F][\x80-\xBF]{2}
-                 )+
-                 '''
+    ( [\x21-\x5A\x5E-\x7E] # Visible ASCII except '[', '\', ']',
+    | {unicode_char}
+    )+
+'''.format(unicode_char=_UNICODE_CHAR)
 
 t_domain_FWSP = r'([\s\t]*\r\n)?[\s\t]+' # folding whitespace
+
 
 def t_domain_error(t):
     log.warning("syntax error in domain lexer, token=%s", t)
 
 # Quoted strings - https://tools.ietf.org/html/rfc5322#section-3.2.4
 
+
 def t_DQUOTE(t):
     r'\"'
     t.lexer.begin('quote')
     return t
+
 
 def t_quote_DQUOTE(t):
     r'\"'
     t.lexer.begin('INITIAL')
     return t
 
+
 t_quote_QTEXT = r'''
-                ( \x21                          # Visable ASCII characters not
-                | [\x23-\x5B]                   #   including '\' or '"'
-                | [\x5D-\x7E]
-                | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
-                | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
-                | [\xE1-\xEC][\x80-\xBF]{2}
-                | \xED[\x80-\x9F][\x80-\xBF]
-                | [\xEE-\xEF][\x80-\xBF]{2}
-                | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
-                | [\xF1-\xF3][\x80-\xBF]{3}
-                | \xF4[\x80-\x8F][\x80-\xBF]{2}
-                )+
-                '''
+    ( [\x21\x23-\x5B\x5D-\x7E]  # Visible ASCII except '"', '\'
+    | {unicode_char}
+    )+
+'''.format(unicode_char=_UNICODE_CHAR)
+
 t_quote_QPAIR = r'''
-                \\                              # '/'
-                ( [\x21-\x7E]                   # Visible ASCII character
-                | \s                            # ' ', technically not valid
-                | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
-                | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
-                | [\xE1-\xEC][\x80-\xBF]{2}
-                | \xED[\x80-\x9F][\x80-\xBF]
-                | [\xEE-\xEF][\x80-\xBF]{2}
-                | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
-                | [\xF1-\xF3][\x80-\xBF]{3}
-                | \xF4[\x80-\x8F][\x80-\xBF]{2}
-                )
-                '''
+    \\             # '\'
+    ( [\x21-\x7E]  # Visible ASCII
+    | \s           # ' ' technically not valid
+    | {unicode_char}
+    )
+'''.format(unicode_char=_UNICODE_CHAR)
 
 t_quote_FWSP = r'([\s\t]*\r\n)?[\s\t]+' # folding whitespace
+
 
 def t_quote_error(t):
     log.warning("syntax error in quoted string lexer, token=%s", t)
@@ -175,31 +160,27 @@ def t_quote_error(t):
 
 # Comments - https://tools.ietf.org/html/rfc5322#section-3.2.2
 
+
 def t_LPAREN(t):
     r'\('
     t.lexer.begin('comment')
     return t
+
 
 def t_comment_RPAREN(t):
     r'\)'
     t.lexer.begin('INITIAL')
     return t
 
+
 t_comment_CTEXT = r'''
-                  ( [\x21-\x27]                   # Visable ASCII characters not
-                  | [\x2a-\x5B]                   #   including '(', ')', or '\'
-                  | [\x5D-\x7E]
-                  | [\xC2-\xDF][\x80-\xBF]        # UTF8-2
-                  | \xE0[\xA0-\xBF][\x80-\xBF]    # UTF8-3
-                  | [\xE1-\xEC][\x80-\xBF]{2}
-                  | \xED[\x80-\x9F][\x80-\xBF]
-                  | [\xEE-\xEF][\x80-\xBF]{2}
-                  | \xF0[\x90-\xBF][\x80-\xBF]{2} # UTF8-4
-                  | [\xF1-\xF3][\x80-\xBF]{3}
-                  | \xF4[\x80-\x8F][\x80-\xBF]{2}
-                  )+
-                  '''
-t_comment_FWSP = r'([\s\t]*\r\n)?[\s\t]+' # folding whitespace
+    ( [\x21-\x27\x2A-\x5B\x5D-\x7E]  # Visible ASCII except '(', ')', or '\'
+    | {unicode_char} )+
+'''.format(unicode_char=_UNICODE_CHAR)
+
+
+# Folding whitespace.
+t_comment_FWSP = r'([\s\t]*\r\n)?[\s\t]+'
 
 def t_comment_error(t):
     log.warning("syntax error in comment lexer, token=%s", t)

--- a/flanker/addresslib/quote.py
+++ b/flanker/addresslib/quote.py
@@ -52,7 +52,7 @@ def smart_unquote(s):
 
 
 def _contains_atoms_only(s):
-    if isinstance(s, six.text_type):
+    if six.PY2 and isinstance(s, six.text_type):
         s = s.encode('utf-8')
     match_result = _RE_ATOM_PHRASE.match(s)
     return match_result and match_result.end(0) == len(s)

--- a/flanker/addresslib/tokenizer.py
+++ b/flanker/addresslib/tokenizer.py
@@ -9,6 +9,8 @@ compiled regular expressions or strings.
 
 import re
 
+import six
+
 LBRACKET   = '<'
 AT_SYMBOL  = '@'
 RBRACKET   = '>'
@@ -91,7 +93,7 @@ class TokenStream(object):
         be either a compiled regex or a string.
         """
         # match single character
-        if isinstance(token, basestring) and len(token) == 1:
+        if isinstance(token, six.string_types) and len(token) == 1:
             if self.peek() == token:
                 self.position += 1
                 return token

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -93,14 +93,19 @@ LONG_HEADER = read_fixture_bytes('messages/long-header.eml')
 ATTACHED_PDF = read_fixture_bytes('messages/attached-pdf.eml')
 
 # addresslib fixture files
-MAILBOX_VALID_TESTS = read_fixture_bytes('mailbox_valid.txt')
-MAILBOX_INVALID_TESTS = read_fixture_bytes('mailbox_invalid.txt')
+MAILBOX_VALID_TESTS = read_fixture_bytes(
+    'mailbox_valid.txt').decode('utf-8')
+MAILBOX_INVALID_TESTS = read_fixture_bytes(
+    'mailbox_invalid.txt').decode('utf-8')
 ABRIDGED_LOCALPART_VALID_TESTS = read_fixture_bytes(
-    'abridged_localpart_valid.txt')
+    'abridged_localpart_valid.txt').decode('utf-8')
 ABRIDGED_LOCALPART_INVALID_TESTS = read_fixture_bytes(
-    'abridged_localpart_invalid.txt')
-URL_VALID_TESTS = read_fixture_bytes('url_valid.txt').decode('utf-8')
-URL_INVALID_TESTS = read_fixture_bytes('url_invalid.txt').decode('utf-8')
-
-DOMAIN_TYPO_VALID_TESTS = read_fixture_bytes('domain_typos_valid.txt')
-DOMAIN_TYPO_INVALID_TESTS = read_fixture_bytes('domain_typos_invalid.txt')
+    'abridged_localpart_invalid.txt').decode('utf-8')
+URL_VALID_TESTS = read_fixture_bytes(
+    'url_valid.txt').decode('utf-8')
+URL_INVALID_TESTS = read_fixture_bytes(
+    'url_invalid.txt').decode('utf-8')
+DOMAIN_TYPO_VALID_TESTS = read_fixture_bytes(
+    'domain_typos_valid.txt').decode('utf-8')
+DOMAIN_TYPO_INVALID_TESTS = read_fixture_bytes(
+    'domain_typos_invalid.txt').decode('utf-8')

--- a/tests/addresslib/address_test.py
+++ b/tests/addresslib/address_test.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import six
 from nose.tools import assert_raises, eq_, ok_
 
 from flanker.addresslib.address import (Address, AddressList, EmailAddress,
@@ -91,8 +92,8 @@ def test_addresslist_basics():
     eq_(lst, clone)
 
     # hostnames:
-    eq_(set(['host.com', 'foo.com', 'yahoo.net', 's.com']), lst.hostnames)
-    eq_(set(['url', 'email']), lst.addr_types)
+    eq_({'host.com', 'foo.com', 'yahoo.net', 's.com'}, lst.hostnames)
+    eq_({'url', 'email'}, lst.addr_types)
 
     # add:
     result = lst + parse_list("ev@local.net") + ["foo@bar.com"]
@@ -442,7 +443,8 @@ def test_address_convertible_2_ascii():
         _typed_eq(tc['ace_address'], addr.ace_address)
         _typed_eq(tc['repr'], repr(addr))
         _typed_eq(tc['str'], str(addr))
-        _typed_eq(tc['unicode'], unicode(addr))
+        if six.PY2:
+            _typed_eq(tc['unicode'], unicode(addr))
         _typed_eq(tc['unicode'], addr.to_unicode())
         _typed_eq(tc['full_spec'], addr.full_spec())
 
@@ -644,7 +646,8 @@ def test_address_requires_utf8():
             _ = addr.ace_address
         _typed_eq(tc['repr'], repr(addr))
         _typed_eq(tc['str'], str(addr))
-        _typed_eq(tc['unicode'], unicode(addr))
+        if six.PY2:
+            _typed_eq(tc['unicode'], unicode(addr))
         _typed_eq(tc['unicode'], addr.to_unicode())
         with assert_raises(ValueError):
             addr.full_spec()
@@ -687,7 +690,8 @@ def test_address_properties_req_utf8():
         addr_list = parse_list(tc['addr_list'])
         eq_(tc['repr'], repr(addr_list))
         eq_(tc['str'], str(addr_list))
-        eq_(tc['unicode'], unicode(addr_list))
+        if six.PY2:
+            eq_(tc['unicode'], unicode(addr_list))
         eq_(tc['unicode'], addr_list.to_unicode())
         if isinstance(tc['full_spec'], Exception):
             assert_raises(type(tc['full_spec']), addr_list.full_spec)

--- a/tests/addresslib/corrector_test.py
+++ b/tests/addresslib/corrector_test.py
@@ -4,6 +4,8 @@ import re
 import string
 import random
 
+import six
+
 from .. import *
 
 from nose.tools import assert_equal, assert_not_equal, ok_
@@ -19,7 +21,10 @@ COMMENT = re.compile(r'''\s*#''')
 @nottest
 def generate_mutated_string(source_str, num):
     letters = list(source_str)
-    rchars = string.ascii_lowercase.translate(None, source_str + '.')
+    if six.PY2:
+        rchars = string.ascii_lowercase.translate(None, source_str + '.')
+    else:
+        rchars = string.ascii_lowercase.translate(source_str + '.')
 
     random_orig = random.sample(list(enumerate(source_str)), num)
     random_new = random.sample(list(enumerate(rchars)), num)
@@ -32,7 +37,10 @@ def generate_mutated_string(source_str, num):
 @nottest
 def generate_longer_string(source_str, num):
     letters = list(source_str)
-    rchars = string.ascii_lowercase.translate(None, source_str)
+    if six.PY2:
+        rchars = string.ascii_lowercase.translate(None, source_str + '.')
+    else:
+        rchars = string.ascii_lowercase.translate(source_str + '.')
 
     for i in range(num):
         letters = [random.choice(rchars)] + letters
@@ -52,7 +60,7 @@ def domain_generator(size=6, chars=string.ascii_letters + string.digits):
 def test_domain_typo_valid_set():
     sugg_correct = 0
     sugg_total = 0
-    print ''
+    print('')
 
     for line in DOMAIN_TYPO_VALID_TESTS.split('\n'):
         # strip line, skip over empty lines
@@ -74,21 +82,21 @@ def test_domain_typo_valid_set():
         if sugg_str == corr_str:
             sugg_correct += 1
         else:
-            print 'did not match: {0}, {1}'.format(test_str, sugg_str)
+            print('did not match: {0}, {1}'.format(test_str, sugg_str))
 
         sugg_total += 1
 
     # ensure that we have greater than 90% accuracy
     accuracy = float(sugg_correct) / sugg_total
-    print 'external valid: accuracy: {0}, correct: {1}, total: {2}'.\
-        format(accuracy, sugg_correct, sugg_total)
+    print('external valid: accuracy: {0}, correct: {1}, total: {2}'
+          .format(accuracy, sugg_correct, sugg_total))
     ok_(accuracy > 0.90)
 
 
 def test_domain_typo_invalid_set():
     sugg_correct = 0
     sugg_total = 0
-    print ''
+    print('')
 
     for line in DOMAIN_TYPO_INVALID_TESTS.split('\n'):
         # strip line, skip over empty lines
@@ -107,14 +115,14 @@ def test_domain_typo_invalid_set():
         if sugg_str == None:
             sugg_correct += 1
         else:
-            print 'incorrect correction: {0}, {1}'.format(test_str, sugg_str)
+            print('incorrect correction: {0}, {1}'.format(test_str, sugg_str))
 
         sugg_total += 1
 
     # ensure that we have greater than 90% accuracy
     accuracy = float(sugg_correct) / sugg_total
-    print 'external invalid: accuracy: {0}, correct: {1}, total: {2}'.\
-        format(accuracy, sugg_correct, sugg_total)
+    print('external invalid: accuracy: {0}, correct: {1}, total: {2}'
+          .format(accuracy, sugg_correct, sugg_total))
     ok_(accuracy > 0.90)
 
 
@@ -129,7 +137,7 @@ def test_domain_typo_invalid_set():
 def test_suggest_alternate_mutations_valid():
     sugg_correct = 0
     sugg_total = 0
-    print ''
+    print('')
 
     for i in range(1, 3):
         for j in range(100):
@@ -145,15 +153,15 @@ def test_suggest_alternate_mutations_valid():
 
     # ensure that we have greater than 60% accuracy
     accuracy = float(sugg_correct) / sugg_total
-    print 'mutations valid: accuracy: {0}, correct: {1}, total: {2}'.\
-        format(accuracy, sugg_correct, sugg_total)
+    print('mutations valid: accuracy: {0}, correct: {1}, total: {2}'
+          .format(accuracy, sugg_correct, sugg_total))
     ok_(accuracy > 0.60)
 
 
 def test_suggest_alternate_longer_valid():
     sugg_correct = 0
     sugg_total = 0
-    print ''
+    print('')
 
     for i in range(1, 3):
         for j in range(100):
@@ -169,15 +177,15 @@ def test_suggest_alternate_longer_valid():
 
     # ensure that we have greater than 60% accuracy
     accuracy = float(sugg_correct) / sugg_total
-    print 'longer valid: accuracy: {0}, correct: {1}, total: {2}'.\
-        format(accuracy, sugg_correct, sugg_total)
+    print('longer valid: accuracy: {0}, correct: {1}, total: {2}'
+          .format(accuracy, sugg_correct, sugg_total))
     ok_(accuracy > 0.60)
 
 
 def test_suggest_alternate_shorter_valid():
     sugg_correct = 0
     sugg_total = 0
-    print ''
+    print('')
 
     for i in range(1, 3):
         for j in range(100):
@@ -193,15 +201,15 @@ def test_suggest_alternate_shorter_valid():
 
     # ensure that we have greater than 60% accuracy
     accuracy = float(sugg_correct) / sugg_total
-    print 'shorter valid: accuracy: {0}, correct: {1}, total: {2}'.\
-        format(accuracy, sugg_correct, sugg_total)
+    print('shorter valid: accuracy: {0}, correct: {1}, total: {2}'
+          .format(accuracy, sugg_correct, sugg_total))
     ok_(accuracy > 0.60)
 
 
 def test_suggest_alternate_invalid():
     sugg_correct = 0
     sugg_total = 0
-    print ''
+    print('')
 
     for i in range(3, 10):
         for j in range(100):
@@ -212,12 +220,12 @@ def test_suggest_alternate_invalid():
             if sugg_str == None:
                 sugg_correct += 1
             else:
-                print 'did not match: {0}, {1}'.format(orig_str, sugg_str)
+                print('did not match: {0}, {1}'.format(orig_str, sugg_str))
 
             sugg_total += 1
 
     # ensure that we have greater than 60% accuracy
     accuracy = float(sugg_correct) / sugg_total
-    print 'alternative invalid: accuracy: {0}, correct: {1}, total: {2}'.\
-        format(accuracy, sugg_correct, sugg_total)
+    print('alternative invalid: accuracy: {0}, correct: {1}, total: {2}'
+          .format(accuracy, sugg_correct, sugg_total))
     ok_(accuracy > 0.60)

--- a/tests/addresslib/parser_address_list_test.py
+++ b/tests/addresslib/parser_address_list_test.py
@@ -103,13 +103,13 @@ def test_parse_list_from_list():
         # Then
         eq_(tc['good'], al)
         eq_(tc['good'], al_from_l)
-        for j in xrange(len(al_from_l)):
+        for j in range(len(al_from_l)):
             _strict_eq(tc['good'][j], al[j])
             _strict_eq(tc['good'][j], al_from_l[j])
         eq_(tc['bad'], bad_from_l)
 
         eq_(tc.get('good_s', tc['good']), al_from_s)
-        for j in xrange(len(al_from_s)):
+        for j in range(len(al_from_s)):
             _strict_eq(tc.get('good_s', tc['good'])[j], al_from_s[j])
         eq_(tc.get('bad_s', tc['bad']), bad_from_s)
 

--- a/tests/addresslib/plugins/aol_test.py
+++ b/tests/addresslib/plugins/aol_test.py
@@ -75,7 +75,7 @@ def test_aol_fail():
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range
-        for i in range(0, 3) + range(33, 40):
+        for i in list(range(0, 3)) + list(range(33, 40)):
             localpart = ''.join(random.choice(string.ascii_letters) for x in range(i))
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)

--- a/tests/addresslib/plugins/gmail_test.py
+++ b/tests/addresslib/plugins/gmail_test.py
@@ -80,7 +80,7 @@ def test_gmail_fail():
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range
-        for i in range(0, 6) + range(31, 40):
+        for i in list(range(0, 6)) + list(range(31, 40)):
             localpart = ''.join(random.choice(string.ascii_letters) for x in range(i))
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)

--- a/tests/addresslib/plugins/google_test.py
+++ b/tests/addresslib/plugins/google_test.py
@@ -90,7 +90,7 @@ def test_google_fail():
             assert_equal(addr, None)
 
         # invalid length range
-        for i in range(0) + range(65, 80):
+        for i in list(range(0)) + list(range(65, 80)):
             localpart = ''.join(random.choice(string.ascii_letters) for x in range(i))
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)

--- a/tests/addresslib/plugins/hotmail_test.py
+++ b/tests/addresslib/plugins/hotmail_test.py
@@ -80,7 +80,7 @@ def test_hotmail_fail():
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range
-        for i in range(0, 0) + range(65, 70):
+        for i in list(range(0, 0)) + list(range(65, 70)):
             localpart = ''.join(random.choice(string.ascii_letters) for x in range(i))
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)

--- a/tests/addresslib/plugins/icloud_test.py
+++ b/tests/addresslib/plugins/icloud_test.py
@@ -84,7 +84,7 @@ def test_icloud_fail():
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range
-        for i in range(0, 3) + range(21, 30):
+        for i in list(range(0, 3)) + list(range(21, 30)):
             localpart = ''.join(random.choice(string.ascii_letters) for x in range(i))
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)

--- a/tests/addresslib/plugins/yahoo_test.py
+++ b/tests/addresslib/plugins/yahoo_test.py
@@ -100,14 +100,14 @@ def test_yahoo_disposable_fail():
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid base length range
-        for i in range(0) + range(33, 40):
+        for i in list(range(0)) + list(range(33, 40)):
             base = ''.join(random.choice(string.ascii_letters) for x in range(i))
             localpart = base + '-aa'
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)
 
         # invalid keyword length range
-        for i in range(0) + range(33, 40):
+        for i in list(range(0)) + list(range(33, 40)):
             keyword = ''.join(random.choice(string.ascii_letters) for x in range(i))
             localpart = 'aa-' + keyword
             addr = address.validate_address(localpart + DOMAIN)
@@ -133,7 +133,7 @@ def test_yahoo_fail():
         mock_method.side_effect = mock_exchanger_lookup
 
         # invalid length range
-        for i in range(0, 4) + range(33, 40):
+        for i in list(range(0, 4)) + list(range(33, 40)):
             localpart = ''.join(random.choice(string.ascii_letters) for x in range(i))
             addr = address.validate_address(localpart + DOMAIN)
             assert_equal(addr, None)

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist = py27, py36
 deps =
     nose
     mock
-commands = nosetests tests/mime/bounce_tests.py
+commands = nosetests []


### PR DESCRIPTION
This PR makes flanker/addresslib Python 3 compatible.

The current functionality when running in Python 2 is not changed. In Python 3 we expect text inputs (str) and all methods that return string types (str/unicode) in Python 2 are returning str unconditionally.

The only problem that I have not yet fixed is that ASCII separator symbols `0x1c, 0x1d, 0x1e, 0x1f` for some reason became allowed in the display name in Python 3.