### PR TITLE
Add a TLD check to validate_address

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -249,7 +249,7 @@ def parse_list(address_list, strict=False, as_tuple=False, metrics=False):
             return _parse_list_result(as_tuple, AddressList(), [address_list], mtimes)
 
         if not strict:
-            _log.info('relaxed parsing is not available for discrete lists, ignoring')
+            _log.debug('relaxed parsing is not available for discrete lists, ignoring')
 
         return parse_discrete_list(address_list, as_tuple=as_tuple, metrics=True)
 
@@ -294,7 +294,7 @@ def validate_address(addr_spec, metrics=False, skip_remote_checks=False):
     paddr = parse(addr_spec, addr_spec_only=True, strict=True)
     mtimes['parsing'] = time() - bstart
     if paddr is None:
-        _log.warning('failed parse check for %s', addr_spec)
+        _log.debug('failed parse check for %s', addr_spec)
         return None, mtimes
 
     # lookup the TLD
@@ -302,7 +302,7 @@ def validate_address(addr_spec, metrics=False, skip_remote_checks=False):
     tld = get_tld(paddr.hostname, fail_silently=True, fix_protocol=True)
     mtimes['tld_lookup'] = time() - bstart
     if tld is None:
-        _log.warning('failed tld check for %s', addr_spec)
+        _log.debug('failed tld check for %s', addr_spec)
         return None, mtimes
 
     if skip_remote_checks:
@@ -314,7 +314,7 @@ def validate_address(addr_spec, metrics=False, skip_remote_checks=False):
     mtimes['dns_lookup'] = mx_metrics['dns_lookup']
     mtimes['mx_conn'] = mx_metrics['mx_conn']
     if exchanger is None:
-        _log.warning('failed mx check for %s', addr_spec)
+        _log.debug('failed mx check for %s', addr_spec)
         return None, mtimes
 
     # lookup custom local-part grammar if it exists
@@ -322,7 +322,7 @@ def validate_address(addr_spec, metrics=False, skip_remote_checks=False):
     plugin = plugin_for_esp(exchanger)
     mtimes['custom_grammar'] = time() - bstart
     if plugin and plugin.validate(paddr) is False:
-        _log.warning('failed custom grammer check for %s/%s', addr_spec, plugin.__name__)
+        _log.debug('failed custom grammer check for %s/%s', addr_spec, plugin.__name__)
         return None, mtimes
 
     return paddr, mtimes
@@ -370,7 +370,7 @@ def validate_list(addr_list, as_tuple=False, metrics=False, skip_remote_checks=F
     # validate each address
     for paddr in parsed_addresses:
         vaddr, metrics = validate_address(paddr.address, metrics=True, skip_remote_checks=skip_remote_checks)
-        for k in set().union(mtimes.keys(), metrics.keys()):
+        for k in mtimes.keys():
             mtimes[k] += metrics[k]
         if vaddr is None:
             ulist.append(paddr.full_spec())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='flanker',
-      version='0.8.3',
+      version='0.8.4',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],
@@ -28,6 +28,7 @@ setup(name='flanker',
           'ply>=3.10',
           'regex>=0.1.20110315',
           'six',
+          'tld',
           'WebOb>=0.9.8'],
       extras_require={
           'validator': [

--- a/tests/addresslib/validator_test.py
+++ b/tests/addresslib/validator_test.py
@@ -142,8 +142,7 @@ def test_parse_syntax_only_false():
     invalid_subdomain_list = [i + '@sub.example.com' for i in invalid_localparts(True)]
 
     all_valid_list = valid_tld_list + valid_domain_list + valid_subdomain_list
-    all_invalid_list = invalid_mx_list + invalid_tld_list + invalid_domain_list + \
-        invalid_subdomain_list
+    all_invalid_list = invalid_domain_list + invalid_subdomain_list + invalid_tld_list + invalid_mx_list
     all_list = all_valid_list + all_invalid_list
 
     # all valid

--- a/tests/addresslib/validator_test.py
+++ b/tests/addresslib/validator_test.py
@@ -334,3 +334,16 @@ def test_mx_aol_manage_flag_toggle():
     addr_obj = address.parse(mailbox)
     unmanaged = validate.aol.unmanaged_email(addr_obj.hostname)
     assert_equal(unmanaged, True)
+
+def test_bad_tld():
+    # con is not a valid TLD
+    addr_spec = 'test@example.con'
+    addr_obj, metrics = address.validate_address(addr_spec, skip_remote_checks=True, metrics=True)
+    assert_equal(addr_obj, None)
+    assert_not_equal(metrics['tld_lookup'], 0)
+
+    # example is not a valid TLD
+    addr_spec = 'test@example'
+    addr_obj, metrics = address.validate_address(addr_spec, skip_remote_checks=True, metrics=True)
+    assert_equal(addr_obj, None)
+    assert_not_equal(metrics['tld_lookup'], 0)


### PR DESCRIPTION
We queue a not insignificant number of messages for domains that do not have a valid TLD. These are mostly typos of common mailbox providers like `user@gmail.con` or `user@gmail`. These addresses are technically valid from a grammer perspective because the domain part is a valid atom or dot atom. This patch should allow us to reject these messages immediately instead of wasting resources trying to deliver them.