### PR TITLE
Remove unnecessary parsing limits

### DIFF
--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -11,12 +11,6 @@ from flanker.mime.message.utils import to_utf8
 
 _log = logging.getLogger(__name__)
 
-# max length for a header line is 80 chars
-# max recursion depth is 1000
-# 80 * 1000 for header is too much for the system
-# so we allow just 100 lines for header
-_MAX_HEADER_LENGTH = 8000
-
 _ADDRESS_HEADERS = ('From', 'To', 'Delivered-To', 'Cc', 'Bcc', 'Reply-To')
 
 
@@ -43,8 +37,6 @@ def encode(name, value):
 
 
 def _encode_unstructured(name, value):
-    if len(value) > _MAX_HEADER_LENGTH:
-        return to_utf8(value)
     try:
         return Header(
             value.encode("ascii"), "ascii",

--- a/flanker/mime/message/headers/parsing.py
+++ b/flanker/mime/message/headers/parsing.py
@@ -8,7 +8,6 @@ from flanker.mime.message.utils import to_unicode
 from flanker.utils import is_pure_ascii
 
 _RE_HEADER = regex.compile(r'^(From |[\041-\071\073-\176]+:|[\t ])')
-_MAX_LINE_LENGTH = 10000
 
 
 def normalize(header_name):
@@ -59,9 +58,6 @@ def _read_header_lines(fp):
     """Read lines with headers until the start of body"""
     lines = deque()
     for line in fp:
-        if len(line) > _MAX_LINE_LENGTH:
-            raise DecodingError('Line is too long: %d' % len(line))
-
         if is_empty(line):
             break
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='flanker',
-      version='0.8.4',
+      version='0.8.5',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[],

--- a/tests/mime/message/create_test.py
+++ b/tests/mime/message/create_test.py
@@ -363,3 +363,16 @@ def create_newlines_in_headers_test():
     text = create.from_string(text.to_string())
     eq_('Hello,newline', text.headers['Subject'])
     eq_(u'Превед, медвед!', text.headers['To'])
+
+
+def test_bug_line_is_too_long():
+    # It was possible to create a message with a very long header value, but
+    # it was impossible to parse such message.
+
+    msg = create.text('plain', 'foo', 'utf-8')
+    msg.headers.add('bar', 'y' * 10000)
+    encoded_msg = msg.to_string()
+    decoded_msg = create.from_string(encoded_msg)
+
+    # When/Then
+    decoded_msg.headers

--- a/tests/mime/message/headers/encoding_test.py
+++ b/tests/mime/message/headers/encoding_test.py
@@ -56,31 +56,16 @@ def max_header_length_test():
     message = create.from_string(LONG_HEADER)
 
     # this used to fail because exceeded max depth recursion
-    ok_(message.headers.getraw('subject').encode("utf-8") in message.to_string())
+    message.to_string()
+
+    ascii_subject = "This is simple ascii subject"
+    eq_(Header(ascii_subject.encode("ascii"), "ascii", header_name="Subject"),
+        _encode_unstructured("Subject", ascii_subject))
 
     unicode_subject = (u"Это сообщение с длинным сабжектом "
                        u"специально чтобы проверить кодировки")
-    ascii_subject = "This is simple ascii subject"
-
-    with patch.object(
-        headers.encoding, '_MAX_HEADER_LENGTH', len(ascii_subject) + 1):
-
-        eq_(Header(ascii_subject.encode("ascii"), "ascii", header_name="Subject"),
-            _encode_unstructured("Subject", ascii_subject))
-
-    with patch.object(
-        headers.encoding, '_MAX_HEADER_LENGTH', len(unicode_subject) + 1):
-
-        eq_(Header(unicode_subject.encode("utf-8"), "utf-8", header_name="Subject"),
-            _encode_unstructured("Subject", unicode_subject))
-
-    with patch.object(headers.encoding, '_MAX_HEADER_LENGTH', 1):
-
-        eq_(ascii_subject.encode("utf-8"),
-            _encode_unstructured("Subject", ascii_subject))
-
-        eq_(unicode_subject.encode("utf-8"),
-            _encode_unstructured("Subject", unicode_subject))
+    eq_(Header(unicode_subject.encode("utf-8"), "utf-8", header_name="Subject"),
+        _encode_unstructured("Subject", unicode_subject))
 
 
 def add_header_preserve_original_encoding_test():

--- a/tests/mime/message/headers/headers_test.py
+++ b/tests/mime/message/headers/headers_test.py
@@ -135,8 +135,7 @@ def headers_parsing_empty_test():
 def headers_parsing_ridiculously_long_line_test():
     val = "abcdefg"*100000
     header = "Hello: {0}\r\n".format(val)
-    assert_raises(
-        DecodingError, MimeHeaders.from_stream, six.StringIO(header))
+    MimeHeaders.from_stream(six.StringIO(header))
 
 
 def headers_parsing_binary_stuff_survives_test():


### PR DESCRIPTION
The following limits were removed:

1. _MAX_HEADER_LENGTH - if a header value exceeded this limit we did not fold the value, but weirdly enough still added it to the mime making it in some cases impossible to parse (e.g. the header line size exceeded _MAX_LINE_LENGTH);
2. _MAX_LINE_LENGTH - the limit was applied *after* a header value was parsed, so resources had already been spent on parsing.