### PR TITLE
Create adaptor module _email for the standard email package

### DIFF
--- a/flanker/_email.py
+++ b/flanker/_email.py
@@ -1,0 +1,98 @@
+import email
+from contextlib import closing
+from email.generator import Generator
+from email.header import Header
+from email.mime import audio
+from email.utils import make_msgid
+
+import six
+from six.moves import StringIO
+
+_CRLF = '\r\n'
+_SPLIT_CHARS = ' ;,'
+
+# The value of email.header.MAXLINELEN constant changed from 76 to 78 in
+# Python 3. To make sure that the library behaviour is consistent across all
+# Python versions we introduced our own constant.
+_MAX_LINE_LEN = 76
+
+
+if six.PY3:
+    from email.policy import Compat32
+
+    class _Compat32CRLF(Compat32):
+        linesep = _CRLF
+
+    _compat32_crlf = _Compat32CRLF()
+
+else:
+    from email import generator, header, quoprimime, feedparser
+    generator.NL = _CRLF
+    header.NL = _CRLF
+    quoprimime.NL = _CRLF
+    feedparser.NL = _CRLF
+
+
+def message_from_string(string):
+    if six.PY3:
+        if isinstance(string, six.binary_type):
+            return email.message_from_bytes(string, policy=_compat32_crlf)
+
+        return email.message_from_string(string, policy=_compat32_crlf)
+
+    return email.message_from_string(string)
+
+
+def message_to_string(msg):
+    """
+    Converts python message to string in a proper way.
+    """
+    with closing(StringIO()) as fp:
+        if six.PY3:
+            g = Generator(fp, mangle_from_=False, policy=_compat32_crlf)
+            g.flatten(msg, unixfrom=False)
+            return fp.getvalue()
+
+        g = Generator(fp, mangle_from_=False)
+        g.flatten(msg, unixfrom=False)
+
+        # In Python 2 Generator.flatten uses `print >> ` to write to fp, that
+        # adds `\n` regardless of generator.NL value. So we resort to a hackish
+        # way of replacing LF with RFC complaint CRLF.
+        for i, v in enumerate(fp.buflist):
+            if v == '\n':
+                fp.buflist[i] = _CRLF
+
+        return fp.getvalue()
+
+
+def format_param(name, val):
+    return email.message._formatparam(name, val)
+
+
+def decode_base64(val):
+    return email.base64mime.decode(val)
+
+
+def encode_base64(val):
+    return email.encoders._bencode(val)
+
+
+def decode_quoted_printable(val):
+    return email.quoprimime.header_decode(val)
+
+
+def detect_audio_type(val):
+    return audio._whatsnd(val)
+
+
+def make_message_id():
+    return make_msgid()
+
+
+def encode_header(name, val, encoding='ascii', max_line_len=_MAX_LINE_LEN):
+    header = Header(val, encoding, max_line_len, name)
+    if six.PY3:
+        return header.encode(_SPLIT_CHARS, linesep=_CRLF)
+
+    return header.encode(_SPLIT_CHARS)

--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -34,7 +34,6 @@ EmailAddress or UrlAddress in flanker.addresslib.address.
 See the parser.py module for implementation details of the parser.
 """
 from logging import getLogger
-from time import time
 
 import idna
 import six
@@ -42,8 +41,10 @@ from idna import IDNAError
 from ply.lex import LexError
 from ply.yacc import YaccError
 from six.moves.urllib_parse import urlparse
+from time import time
 from tld import get_tld
 
+from flanker import _email
 from flanker.addresslib._parser.lexer import lexer
 from flanker.addresslib._parser.parser import (Mailbox, Url, mailbox_parser,
                                                mailbox_or_url_parser,
@@ -53,7 +54,6 @@ from flanker.addresslib.quote import smart_unquote, smart_quote
 from flanker.addresslib.validate import (mail_exchanger_lookup,
                                          plugin_for_esp)
 from flanker.mime.message.headers.encodedword import mime_to_unicode
-from flanker.mime.message.headers.encoding import encode_string
 from flanker.utils import is_pure_ascii, metrics_wrapper
 
 _log = getLogger(__name__)
@@ -503,8 +503,10 @@ class EmailAddress(Address):
 
     @property
     def ace_display_name(self):
-        return _to_str(encode_string(None, smart_quote(self._display_name),
-                                     maxlinelen=MAX_ADDRESS_LENGTH))
+        quoted_display_name = smart_quote(self._display_name)
+        encoded_display_name = _email.encode_header(None, quoted_display_name,
+                                                    'ascii', MAX_ADDRESS_LENGTH)
+        return _to_str(encoded_display_name)
 
     @property
     def mailbox(self):

--- a/flanker/mime/__init__.py
+++ b/flanker/mime/__init__.py
@@ -63,5 +63,4 @@ from flanker.mime.message.errors import DecodingError, EncodingError, MimeError
 from flanker.mime import create
 from flanker.mime.create import from_string
 from flanker.mime.message.fallback.create import from_string as recover
-from flanker.mime.message.utils import python_message_to_string
 from flanker.mime.message.headers.parametrized import fix_content_type

--- a/flanker/mime/create.py
+++ b/flanker/mime/create.py
@@ -1,12 +1,15 @@
-""" This package is a set of utilities and methods for building mime messages """
+"""
+This package is a set of utilities and methods for building mime messages.
+"""
 
 import uuid
+
+from flanker import _email
 from flanker.mime import DecodingError
-from flanker.mime.message import ContentType, utils
-from flanker.mime.message.part import MimePart, Body, Part, adjust_content_type
-from flanker.mime.message import scanner
-from flanker.mime.message.headers.parametrized import fix_content_type
+from flanker.mime.message import ContentType, scanner
 from flanker.mime.message.headers import WithParams
+from flanker.mime.message.headers.parametrized import fix_content_type
+from flanker.mime.message.part import MimePart, Body, Part, adjust_content_type
 
 
 def multipart(subtype):
@@ -84,8 +87,7 @@ def from_string(string):
 
 
 def from_python(message):
-    return from_string(
-        utils.python_message_to_string(message))
+    return from_string(_email.message_to_string(message))
 
 
 def from_message(message):

--- a/flanker/mime/message/fallback/create.py
+++ b/flanker/mime/message/fallback/create.py
@@ -1,15 +1,9 @@
-import email
-
-import six
-
+from flanker import _email
 from flanker.mime.message.fallback.part import FallbackMimePart
 
 
 def from_string(string):
-    if six.PY3 and isinstance(string, six.binary_type):
-        string = string.decode('utf-8')
-
-    return FallbackMimePart(email.message_from_string(string))
+    return FallbackMimePart(_email.message_from_string(string))
 
 
 def from_python(message):

--- a/flanker/mime/message/fallback/part.py
+++ b/flanker/mime/message/fallback/part.py
@@ -1,14 +1,15 @@
 import logging
-import email
 
 import six
 from webob.multidict import MultiDict
+
+from flanker import _email
+from flanker.mime.message import headers
 from flanker.mime.message.charsets import convert_to_unicode
+from flanker.mime.message.headers import parametrized, normalize
 from flanker.mime.message.headers.headers import remove_newlines, MimeHeaders
 from flanker.mime.message.part import RichPartMixin
 from flanker.mime.message.scanner import ContentType
-from flanker.mime.message import utils, headers
-from flanker.mime.message.headers import parametrized, normalize
 
 log = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ class FallbackMimePart(RichPartMixin):
         pass  # FIXME Not implement
 
     def to_string(self):
-        return utils.python_message_to_string(self._m)
+        return _email.message_to_string(self._m)
 
     def to_stream(self, out):
         out.write(self.to_string())
@@ -98,7 +99,7 @@ class FallbackMimePart(RichPartMixin):
 
     def append(self, *messages):
         for m in messages:
-            part = FallbackMimePart(email.message_from_string(m.to_string()))
+            part = FallbackMimePart(_email.message_from_string(m.to_string()))
             self._m.attach(part)
 
     @property

--- a/flanker/mime/message/headers/encodedword.py
+++ b/flanker/mime/message/headers/encodedword.py
@@ -1,12 +1,11 @@
 # coding:utf-8
-import email.base64mime
-import email.quoprimime
 import logging
 from base64 import b64encode
 
 import regex as re
 import six
 
+from flanker import _email
 from flanker.mime.message import charsets, errors
 
 _log = logging.getLogger(__name__)
@@ -113,7 +112,7 @@ def _decode_part(charset, encoding, value):
         if paderr:
             value += '==='[:4 - paderr]
 
-        return charset, email.base64mime.decode(value)
+        return charset, _email.decode_base64(value)
 
     if not encoding:
         return charset, value
@@ -123,7 +122,7 @@ def _decode_part(charset, encoding, value):
 
 def _decode_quoted_printable(qp):
     if six.PY2:
-        return email.quoprimime.header_decode(str(qp))
+        return _email.decode_quoted_printable(str(qp))
 
     buf = bytearray()
     size = len(qp)

--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -1,20 +1,14 @@
-import email.message
 import logging
 from collections import deque
-from email.header import Header
 
 import six
 
 import flanker.addresslib.address
+from flanker import _email
 from flanker.mime.message.headers import parametrized
 from flanker.mime.message.utils import to_utf8
 
 _log = logging.getLogger(__name__)
-
-# The value of email.header.MAXLINELEN constant changed from 76 to 78 in
-# Python 3. To make sure that the library behaviour is consistent across all
-# Python versions we introduced our own constant.
-_MAX_LINE_LEN = 76
 
 _ADDRESS_HEADERS = ('From', 'To', 'Delivered-To', 'Cc', 'Bcc', 'Reply-To')
 
@@ -43,14 +37,12 @@ def encode(name, value):
 
 def _encode_unstructured(name, value):
     try:
-        header = Header(value.encode('ascii'), 'ascii', header_name=name)
-        return header.encode(splitchars=' ;,')
+        return _email.encode_header(name, value.encode('ascii'), 'ascii')
     except (UnicodeEncodeError, UnicodeDecodeError):
         if _is_address_header(name, value):
             return _encode_address_header(name, value)
 
-        header = Header(to_utf8(value), 'utf-8', header_name=name)
-        return header.encode(splitchars=' ;,')
+        return _email.encode_header(name, to_utf8(value), 'utf-8')
 
 
 def _encode_address_header(name, value):
@@ -80,20 +72,11 @@ def _encode_param(key, name, value):
         if six.PY2:
             value = value.encode('ascii')
 
-        return email.message._formatparam(name, value)
+        return _email.format_param(name, value)
     except Exception:
-        header = Header(value.encode('utf-8'), 'utf-8', header_name=key)
-        value = header.encode(splitchars=' ;,')
-        return email.message._formatparam(name, value)
-
-
-def encode_string(name, value, maxlinelen=_MAX_LINE_LEN):
-    try:
-        header = Header(value.encode('ascii'), 'ascii', maxlinelen, name)
-    except UnicodeEncodeError:
-        header = Header(value.encode('utf-8'), 'utf-8', maxlinelen, name)
-
-    return header.encode(splitchars=' ;,')
+        value = value.encode('utf-8')
+        encoded_param = _email.encode_header(key, value, 'utf-8')
+        return _email.format_param(name, encoded_param)
 
 
 def _is_address_header(key, val):

--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -1,13 +1,11 @@
 """ Useful wrappers for headers with parameters,
 provide some convenience access methods
 """
-
-from email.utils import make_msgid
-
 import regex as re
 import six
 
 import flanker.addresslib.address
+from flanker import _email
 
 
 class WithParams(tuple):
@@ -164,7 +162,7 @@ class MessageId(str):
 
     @classmethod
     def generate(cls, domain=None):
-        message_id = make_msgid().strip("<>")
+        message_id = _email.make_message_id().strip("<>")
         if domain:
             local = message_id.split('@')[0]
             message_id = "{0}@{1}".format(local, domain)

--- a/flanker/mime/message/threading.py
+++ b/flanker/mime/message/threading.py
@@ -1,9 +1,9 @@
 """
 Implements message threading
 """
-from email.utils import make_msgid
-
 import six
+
+from flanker import _email
 
 
 def build_thread(messages):
@@ -45,7 +45,7 @@ def map_message(message, table):
     # our current message to another container
     # otherwise the message would be lost
     if this.message:
-        fake_id = make_msgid()
+        fake_id = _email.make_message_id()
         this = container(fake_id)
     this.message = w
 
@@ -200,5 +200,5 @@ class Container(object):
 class Wrapper(object):
     def __init__(self, message):
         self.message = message
-        self.message_id = message.message_id or make_msgid()
+        self.message_id = message.message_id or _email.make_message_id()
         self.references = message.references

--- a/flanker/mime/message/utils.py
+++ b/flanker/mime/message/utils.py
@@ -1,6 +1,3 @@
-from contextlib import closing
-from email.generator import Generator
-
 import chardet as fallback_detector
 import six
 
@@ -11,16 +8,6 @@ except ImportError:
     primary_detector = fallback_detector
 
 from flanker.mime.message import errors
-
-
-def python_message_to_string(msg):
-    """
-    Converts python message to string in a proper way.
-    """
-    with closing(six.StringIO()) as fp:
-        g = Generator(fp, mangle_from_=False)
-        g.flatten(msg, unixfrom=False)
-        return fp.getvalue()
 
 
 def _guess_and_convert_with(value, detector=primary_detector):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,16 @@ def read_fixture(path, binary=False):
     absolute_path = join(abspath(dirname(__file__)), 'fixtures', path)
     mode = 'rb' if binary else 'r'
     with open(absolute_path, mode) as f:
-        return f.read()
+        content = f.read()
+
+    if binary:
+        return content
+
+    # Normalize newline to be CRLF.
+    content = content.replace('\r\n', '\n')
+    content = content.replace('\r', '\n')
+    content = content.replace('\n', '\r\n')
+    return content
 
 
 # mime fixture files

--- a/tests/addresslib/parser_mailbox_test.py
+++ b/tests/addresslib/parser_mailbox_test.py
@@ -532,7 +532,7 @@ def test_full_spec_symmetry_bug():
     the display name words.
     """
     # Given
-    original = 'very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong <foo@example.com>'
+    original = 'very l' + ('o' * 70) + 'ng <foo@example.com>'
     addr = address.parse(original)
 
     # When

--- a/tests/addresslib/parser_test.py
+++ b/tests/addresslib/parser_test.py
@@ -1,12 +1,9 @@
 # coding:utf-8
 
-import email.header
+from nose.tools import assert_equal, assert_true, assert_false
 
 from flanker.addresslib.address import is_email
 from flanker.mime.message.headers.encodedword import mime_to_unicode
-from mock import patch, Mock
-from nose.tools import assert_equal, assert_not_equal
-from nose.tools import assert_true, assert_false
 
 
 def test_is_email():

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -1,0 +1,17 @@
+from nose.tools import eq_
+
+from flanker import _email
+
+
+def test_encode_header_maxlinelen():
+    """
+    If the encoded string is longer then the maximum line length, which is 76,
+    by default then it is broken down into lines. But a maximum line length
+    value can be provided in the `maxlinelen` parameter.
+    """
+    eq_('very\r\n l' + ('o' * 70) + 'ng',
+        _email.encode_header(None, 'very l' + ('o' * 70) + 'ng'))
+
+    eq_('very l' + ('o' * 70) + 'ng',
+        _email.encode_header(None, 'very l' + ('o' * 70) + 'ng',
+                             max_line_len=78))

--- a/tests/mime/bounce_tests.py
+++ b/tests/mime/bounce_tests.py
@@ -12,20 +12,20 @@ def test_bounce_detect():
             score=1.875,
             status=u'5.1.1',
             notification=(
-                    u"This is the mail system at host mail.example.com.\n\n"
-                    u"I'm sorry to have to inform you that your message could not\n"
-                    u"be delivered to one or more recipients. It's attached below.\n\n"
-                    u"For further assistance, please send mail to postmaster.\n\n"
-                    u"If you do so, please include this problem report. You can\n"
-                    u"delete your own text from the attached returned message.\n\n"
-                    u"                   The mail system\n\n"
-                    u"<asdfasdfasdfasdfasdfasdfewrqertrtyrthsfgdfgadfqeadvxzvz@gmail.com>: host\n"
-                    u"    gmail-smtp-in.l.google.com[209.85.210.17] said: 550-5.1.1 The email account\n"
-                    u"    that you tried to reach does not exist. Please try 550-5.1.1\n"
-                    u"    double-checking the recipient's email address for typos or 550-5.1.1\n"
-                    u"    unnecessary spaces. Learn more at                              550 5.1.1\n"
-                    u"    http://mail.google.com/support/bin/answer.py?answer=6596 17si20661415yxe.22\n"
-                    u"    (in reply to RCPT TO command)\n"),
+                    u"This is the mail system at host mail.example.com.\r\n\r\n"
+                    u"I'm sorry to have to inform you that your message could not\r\n"
+                    u"be delivered to one or more recipients. It's attached below.\r\n\r\n"
+                    u"For further assistance, please send mail to postmaster.\r\n\r\n"
+                    u"If you do so, please include this problem report. You can\r\n"
+                    u"delete your own text from the attached returned message.\r\n\r\n"
+                    u"                   The mail system\r\n\r\n"
+                    u"<asdfasdfasdfasdfasdfasdfewrqertrtyrthsfgdfgadfqeadvxzvz@gmail.com>: host\r\n"
+                    u"    gmail-smtp-in.l.google.com[209.85.210.17] said: 550-5.1.1 The email account\r\n"
+                    u"    that you tried to reach does not exist. Please try 550-5.1.1\r\n"
+                    u"    double-checking the recipient's email address for typos or 550-5.1.1\r\n"
+                    u"    unnecessary spaces. Learn more at                              550 5.1.1\r\n"
+                    u"    http://mail.google.com/support/bin/answer.py?answer=6596 17si20661415yxe.22\r\n"
+                    u"    (in reply to RCPT TO command)\r\n"),
             diagnostic_code=(
                     u"smtp; 550-5.1.1 The email account that you tried to reach does"
                     u"    not exist. Please try 550-5.1.1 double-checking the recipient's email"

--- a/tests/mime/message/create_test.py
+++ b/tests/mime/message/create_test.py
@@ -1,18 +1,14 @@
 # coding:utf-8
 
-from nose.tools import *
-from mock import *
-
-import email
 import json
+from email.parser import Parser
 
-from base64 import b64decode
+from nose.tools import *
 
+from flanker import _email
 from flanker.mime import create
 from flanker.mime.message import errors
 from flanker.mime.message.part import MimePart
-from email.parser import Parser
-
 from ... import *
 
 
@@ -36,7 +32,7 @@ def from_string_message_test():
     message = create.from_string(IPHONE)
     parts = list(message.walk())
     eq_(3, len(parts))
-    eq_(u'\n\n\n~Danielle', parts[2].body)
+    eq_(u'\r\n\r\n\r\n~Danielle', parts[2].body)
 
 
 def from_part_message_simple_test():
@@ -44,7 +40,7 @@ def from_part_message_simple_test():
     parts = list(message.walk())
 
     message = create.from_message(parts[2])
-    eq_(u'\n\n\n~Danielle', message.body)
+    eq_(u'\r\n\r\n\r\n~Danielle', message.body)
 
 
 def message_from_garbage_test():
@@ -75,7 +71,7 @@ def create_singlepart_ascii_long_lines_test():
     eq_("quoted-printable", message2.content_encoding.value)
     eq_(very_long, message2.body)
 
-    message2 = email.message_from_string(message.to_string())
+    message2 = _email.message_from_string(message.to_string())
     eq_(very_long, message2.get_payload(decode=True))
 
 
@@ -95,7 +91,7 @@ def create_multipart_simple_test():
     eq_("Hello", message.parts[0].body)
     eq_("<html>Hello</html>", message.parts[1].body)
 
-    message2 = email.message_from_string(message.to_string())
+    message2 = _email.message_from_string(message.to_string())
     eq_("multipart/mixed", message2.get_content_type())
     eq_("Hello", message2.get_payload()[0].get_payload(decode=False))
     eq_("<html>Hello</html>",
@@ -121,7 +117,7 @@ def create_multipart_with_attachment_test():
     eq_(filename, message2.parts[2].content_type.params['name'])
     ok_(message2.parts[2].is_attachment())
 
-    message2 = email.message_from_string(message.to_string())
+    message2 = _email.message_from_string(message.to_string())
     eq_(3, len(message2.get_payload()))
     eq_(MAILGUN_PNG, message2.get_payload()[2].get_payload(decode=True))
 

--- a/tests/mime/message/headers/encoding_test.py
+++ b/tests/mime/message/headers/encoding_test.py
@@ -1,15 +1,11 @@
 # coding:utf-8
 
-from email.header import Header
-
-from nose.tools import eq_, ok_
 from mock import patch, Mock
+from nose.tools import eq_, ok_
 
-from flanker.mime.message import headers
-from flanker.mime.message.headers.encoding import (_encode_unstructured,
-                                                   encode_string)
-from flanker.mime.message import part
 from flanker.mime import create
+from flanker.mime.message import headers, part
+from flanker.mime.message.headers.encoding import _encode_unstructured
 from tests import LONG_HEADER, ENCODED_HEADER
 
 
@@ -27,7 +23,7 @@ def encodings_test():
     s = ("This is a long subject with commas, bob, Jay, suzy, tom, over"
          " 75,250,234 times!")
     folded_s = ("This is a long subject with commas, bob, Jay, suzy, tom, over"
-                "\n 75,250,234 times!")
+                "\r\n 75,250,234 times!")
     eq_(folded_s, headers.to_mime('Subject', s))
 
 
@@ -38,19 +34,6 @@ def encode_address_test():
     eq_('=?utf-8?b?0KTQtdC00L7Rgg==?= <foo@xn--h1aigbl0e.xn--p1ai>', headers.to_mime('To', 'Федот <foo@письмо.рф>'))
 
 
-def string_maxlinelen_test():
-    """
-    If the encoded string is longer then the maximum line length, which is 76,
-    by default then it is broken down into lines. But a maximum line length
-    value can be provided in the `maxlinelen` parameter.
-    """
-    eq_("very\n loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
-        encode_string(None, "very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"))
-
-    eq_("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
-        encode_string(None, "very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong", maxlinelen=78))
-
-
 @patch.object(part.MimePart, 'was_changed', Mock(return_value=True))        
 def max_header_length_test():
     message = create.from_string(LONG_HEADER)
@@ -58,14 +41,17 @@ def max_header_length_test():
     # this used to fail because exceeded max depth recursion
     message.to_string()
 
-    ascii_subject = "This is simple ascii subject"
-    eq_(Header(ascii_subject.encode("ascii"), "ascii", header_name="Subject").encode(),
-        _encode_unstructured("Subject", ascii_subject))
+    ascii_subject = 'This is simple ascii subject'
+    eq_('This is simple ascii subject',
+        _encode_unstructured('Subject', ascii_subject))
 
-    unicode_subject = (u"Это сообщение с длинным сабжектом "
-                       u"специально чтобы проверить кодировки")
-    eq_(Header(unicode_subject.encode("utf-8"), "utf-8", header_name="Subject").encode(),
-        _encode_unstructured("Subject", unicode_subject))
+    unicode_subject = (u'Это сообщение с длинным сабжектом '
+                       u'специально чтобы проверить кодировки')
+    eq_('=?utf-8?b?0K3RgtC+INGB0L7QvtCx0YnQtdC90LjQtSDRgSDQtNC70LjQvdC9?=\r\n'
+        ' =?utf-8?b?0YvQvCDRgdCw0LHQttC10LrRgtC+0Lwg0YHQv9C10YbQuNCw0LvRjNC90L4g?=\r\n'
+        ' =?utf-8?b?0YfRgtC+0LHRiyDQv9GA0L7QstC10YDQuNGC0Ywg0LrQvtC00LjRgNC+0LI=?=\r\n'
+        ' =?utf-8?b?0LrQuA==?=',
+        _encode_unstructured('Subject', unicode_subject))
 
 
 def add_header_preserve_original_encoding_test():

--- a/tests/mime/message/scanner_test.py
+++ b/tests/mime/message/scanner_test.py
@@ -1,10 +1,9 @@
 # coding:utf-8
 from nose.tools import *
-from mock import *
-from flanker.mime.message.scanner import scan, ContentType, Boundary
-from flanker.mime.message.errors import DecodingError
-from email import message_from_string
 
+from flanker import _email
+from flanker.mime.message.errors import DecodingError
+from flanker.mime.message.scanner import scan, ContentType, Boundary
 from ... import *
 
 C = ContentType
@@ -15,7 +14,7 @@ def no_ctype_headers_and_and_boundaries_test():
     """We are ok, when there is no content type and boundaries"""
     message = scan(NO_CTYPE)
     eq_(C('text', 'plain', dict(charset='ascii')), message.content_type)
-    pmessage = message_from_string(NO_CTYPE)
+    pmessage = _email.message_from_string(NO_CTYPE)
     eq_(message.body, pmessage.get_payload(decode=True))
     for a, b in zip(NO_CTYPE_HEADERS, message.headers.iteritems()):
         eq_(a, b)
@@ -23,7 +22,7 @@ def no_ctype_headers_and_and_boundaries_test():
 
 def multipart_message_test():
     message = scan(EIGHT_BIT)
-    pmessage = message_from_string(EIGHT_BIT)
+    pmessage = _email.message_from_string(EIGHT_BIT)
 
     eq_(C('multipart', 'alternative', dict(boundary='=-omjqkVTVbwdgCWFRgIkx')),
         message.content_type)
@@ -37,7 +36,7 @@ def multipart_message_test():
 
 def enclosed_message_test():
     message = scan(ENCLOSED)
-    pmessage = message_from_string(ENCLOSED)
+    pmessage = _email.message_from_string(ENCLOSED)
 
     eq_(C('multipart', 'mixed',
           dict(boundary='===============6195527458677812340==')),


### PR DESCRIPTION
Module `_email` is introduced to hide all calls to the standard `email` package in one place. The package behaviour changed considerably between Python 2 and Python 3, and this change is supposed to simplify further work on Python 3 support.

Besides the library now consistently produces all CRLF ended strings, previously it was a mixture of `CRLF` and `LF` depending on whether Flanker native code or the standard `email` package was used to produce a line of code.