### PR TITLE
Improved py36 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+htmlcov
 nosetests.xml
 
 # Translations

--- a/flanker/addresslib/validate.py
+++ b/flanker/addresslib/validate.py
@@ -205,7 +205,9 @@ def lookup_domain(domain):
     package for more details.
     """
     fqdn = domain if domain[-1] == '.' else ''.join([domain, '.'])
+
     mx_hosts = _get_dns_lookup()[fqdn]
+    mx_hosts = list(mx_hosts)
 
     if len(mx_hosts) == 0:
         return None

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@
 
 from setuptools import setup, find_packages
 
+tests_require = [
+    'coverage',
+    'coveralls',
+    'mock',
+    'nose',
+],
+
 setup(name='flanker',
       version='0.9.2',
       description='Mailgun Parsing Tools',
@@ -24,10 +31,7 @@ setup(name='flanker',
       packages=find_packages(exclude=['tests']),
       include_package_data=True,
       zip_safe=True,
-      tests_require=[
-          'nose',
-          'mock'
-      ],
+      tests_require=tests_require,
       install_requires=[
           'attrs',
           'chardet>=1.0.1',
@@ -45,5 +49,6 @@ setup(name='flanker',
           ],
           'cchardet': [
               'cchardet>=0.3.5',
-          ]
+          ],
+          'tests': tests_require,
       })

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,5 @@
 envlist = py27, py36
 
 [testenv]
-deps =
-    nose
-    mock
-commands = nosetests []
+deps = .[cchardet,validator,tests]
+commands = nosetests --with-coverage --cover-package=flanker


### PR DESCRIPTION
The changes made here are dealing with the differences between iteration functions in py3 and py2. Specifically, `dnsq` returns a result of a filter function from its `mx_hosts_for` function. In Python 2 it's a list, but for py3 it's an iterator. Later flanker tries to get a `len` of that list which is impossible with an iterator. So this pull request deals with this by converting iterator to a list. 

Other than that there are some improvements in tests.