### PR TITLE
Use charset in case of header decoding

### DIFF
--- a/tests/mime/message/headers/encodedword_test.py
+++ b/tests/mime/message/headers/encodedword_test.py
@@ -1,10 +1,11 @@
 # coding:utf-8
 
-from nose.tools import *
+from nose.tools import eq_
 from mock import *
 from flanker.mime.message.headers import encodedword
 from flanker.mime.message import utils
 from flanker.mime.message import errors, charsets
+from flanker.addresslib.address import parse
 
 def encoded_word_test():
     def t(value):
@@ -136,6 +137,9 @@ def various_encodings_test():
 
     v = u'=?gb18030?Q?Hey_There=D7=B2=D8=B0?='
     eq_(u'Hey There撞匕', encodedword.mime_to_unicode(v))
+
+    v = parse(u'Тест длинного дисплей нейма <test@example.com>')
+    eq_(v.display_name, encodedword.mime_to_unicode(v.ace_display_name))
 
 
 @patch.object(utils, '_guess_and_convert', Mock(side_effect=errors.EncodingError()))


### PR DESCRIPTION
If a header was encoded it can be represented as multiple 'encoded-word's. For instance string `Тест длинного дисплей нейма` is encoded like 
`=?utf-8?b?0KLQtdGB0YIg0LTQu9C40L3QvdC+0LPQviDQtNC40YHQv9C70LXQuSDQvdC10LnQ?=\n =?utf-8?b?vNCw?=`. So in this example the ending of the first encoded-word in the middle of one UTF8 character. The method **mime_to_unicode** treated two words separately so the decoding result was `Тест длинного дисплей ней�МаА`. The fix make a concatenation of 'encoded-word's with the same charset and convert only the whole string to unicode.