### PR TITLE
Restore compatibility with older versions of regex

### DIFF
--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -182,7 +182,7 @@ class MessageId(str):
 
 
 class Subject(six.text_type):
-    RE_RE = re.compile("((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
+    RE_RE = re.compile("((RE|FW|FWD|HA)([\[\]\d])*:\s*)*", re.I)
 
     def __new__(cls, *args, **kw):
         return six.text_type.__new__(cls, *args, **kw)


### PR DESCRIPTION
If applied, this PR will make flanker able to run with versions of `regex` older than 2017.07.xx. 