### PR TITLE
Pin tld package to maintain py2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='flanker',
           'ply>=3.10',
           'regex>=0.1.20110315',
           'six',
-          'tld',
+          'tld==0.10',
           'WebOb>=0.9.8'],
       extras_require={
           'validator': [


### PR DESCRIPTION
In order to maintain py2 support tld needs to be pinned : `tld==0.10`
https://github.com/barseghyanartur/tld/releases