### PR TITLE
Account for message/global enclosed Content Type

### DIFF
--- a/flanker/mime/message/fallback/part.py
+++ b/flanker/mime/message/fallback/part.py
@@ -111,7 +111,7 @@ class FallbackMimePart(RichPartMixin):
 
     @property
     def enclosed(self):
-        if self.content_type == 'message/rfc822':
+        if self.content_type == 'message/rfc822' or self.content_type == 'message/global':
             return FallbackMimePart(self._m.get_payload()[0])
 
     def enclose(self, message):

--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -78,7 +78,7 @@ class ContentType(tuple):
         return self == 'message/external-body'
 
     def is_message_container(self):
-        return self == 'message/rfc822' or self == 'message/news'
+        return self == 'message/rfc822' or self == 'message/global' or self == 'message/news'
 
     def is_disposition_notification(self):
         return self == 'message/disposition-notification'

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -353,7 +353,7 @@ class RichPartMixin(object):
         """
         try:
             for part in self.walk(with_self=True):
-                if part.content_type == 'message/rfc822':
+                if part.content_type == 'message/rfc822' or part.content_type == 'message/global':
                     for p in part.walk():
                         return p
         except Exception:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -66,6 +66,7 @@ ENCLOSED_ENDLESS = read_fixture('messages/enclosed-endless.eml')
 ENCLOSED_BROKEN_BODY = read_fixture('messages/enclosed-broken-body.eml')
 ENCLOSED_BROKEN_ENCODING = read_fixture(
     'messages/enclosed-bad-encoding.eml', binary=True)
+ENCLOSED_GLOBAL = read_fixture('messages/enclosed-global.eml') 
 FALSE_MULTIPART = read_fixture('messages/false-multipart.eml')
 ENCODED_HEADER = read_fixture('messages/encoded-header.eml')
 MESSAGE_EXTERNAL_BODY= read_fixture(

--- a/tests/fixtures/messages/enclosed-global.eml
+++ b/tests/fixtures/messages/enclosed-global.eml
@@ -1,0 +1,99 @@
+                                                                                                                                                                                                                                                               
+Delivered-To: bob@example.com
+Received: by 10.231.77.161 with SMTP id g33csp198901ibk;
+        Sat, 30 Jun 2012 06:06:01 -0700 (PDT)
+Received: by 10.224.70.144 with SMTP id d16mr10884157qaj.45.1341061559897;
+        Sat, 30 Jun 2012 06:05:59 -0700 (PDT)
+Return-Path: <bob@example.net>
+Received: from mail-p1.example.net (mail-p1.example.net. [173.193.210.44])
+        by mx.google.com with ESMTP id o4si2503040qct.204.2012.06.30.06.05.59;
+        Sat, 30 Jun 2012 06:05:59 -0700 (PDT)
+Received-SPF: pass (google.com: domain of bob@example.net designates 173.193.210.44 as permitted sender) client-ip=173.193.210.44;
+Authentication-Results: mx.google.com; spf=pass (google.com: domain of bob@example.net designates 173.193.210.44 as permitted sender) smtp.mail=bob@example.net; dkim=pass header.i=@example.net
+DKIM-Signature: a=rsa-sha256; v=1; c=relaxed/relaxed; d=example.net; q=dns/txt; s=mg;
+ t=1341061559; h=Content-Type: MIME-Version: Message-Id: Date: From: To:
+ Subject; bh=Ukt6EhQREBbLuCk1QdiXVN/+bRJDy1dNWXTIMnC6wJY=; b=k8md2tTxJcL3RUS+nJ2VDLepI7vmQ+myXSTmt7lZ3B0FywfJtSwqfxOtjzybij6Od5ZMDQDB
+ x4GCvgas2t35FERlYDqUpJ2P6Me/uym5UC9779Y3YgqmKAsNyVsxwEkEG/hBmZ6KbkDtrQyP
+ oTwyx05rp1a7N8XxZPH7PiJqevk=
+DomainKey-Signature: a=rsa-sha1; c=nofws; d=example.net; s=mg; q=dns;
+ h=Content-Type: MIME-Version: Message-Id: Date: From: To: Subject;
+ b=IC6Vz0XP40oeA2RCrrwwma9G76F9P9KsJPP7m81Kx3mJeNdj724/kYaFX+6TShpl0sgSHp
+ 9v8DJmudnhJP05YZgr2RIcB5oE8JphkknpbSybB6Kx+IdHQqLVAi+G65BoF/3iAo1e4eBovN
+ yuBbhhO+OBGLuCRlpu3kP2BVtNyxE=
+Content-Type: multipart/mixed; boundary="===============6195527458677812340=="
+MIME-Version: 1.0
+Received: by luna.example.net with SMTP mgrt 8979437;
+ Sat, 30 Jun 2012 13:05:59 +0000
+Received: from [192.168.1.75] (95x79x59x37.static-business.nn.ertelecom.ru
+ [95.79.59.37]) by mxa.example.org with ESMTP id 4feef9b5.5cf5c00-luna2;
+ Sat, 30 Jun 2012 13:05:57 -0000 (UTC)
+Message-Id: <4FEEF9B3.7060508@example.net>
+Date: Sat, 30 Jun 2012 17:05:55 +0400
+From: Bob Marley <bob@example.net>
+User-Agent: Mozilla/5.0 (X11; Linux x86_64;
+ rv:13.0) Gecko/20120615 Thunderbird/13.0.1
+To: "=?utf-8?b?0JDQu9C10LrRgdCw0L3QtNGAINCa0LvQuNC20LXQvdGC0LDRgeKYrw==?="
+ <bob@example.com>
+Subject: Wow
+X-Example-Sid: WyJlYzgyNiIsICJrbGl6aGVudGFzQGdtYWlsLmNvbSIsICIxNyJd
+
+--===============6195527458677812340==
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"; format="flowed"
+Content-Transfer-Encoding: 7bit
+
+Hello
+
+--===============6195527458677812340==
+Content-Type: message/global; name="thanks.eml"
+MIME-Version: 1.0
+
+Content-Type: multipart/alternative;
+ boundary="===============4360815924781479146=="
+MIME-Version: 1.0
+Received: by 127.0.1.1 with SMTP; Fri, 22 Apr 2011 18:21:06 +0000
+Received: from mail-vw0-f51.google.com (mail-vw0-f51.google.com
+ [209.85.212.51])	by mxa.example.org (Postfix) with ESMTPS id 9F1E6F01FAC	for
+ <bob@example.net>; Fri, 22 Apr 2011 18:21:06 +0000 (UTC)
+Received: by vws20 with SMTP id 20so857812vws.24 for <bob@example.net>;
+ Fri, 22 Apr 2011 11:21:06 -0700 (PDT)
+Received: by 10.52.66.82 with SMTP id d18mr2018166vdt.260.1303496466294;
+ Fri, 22 Apr 2011 11:21:06 -0700 (PDT)
+Received: by 10.52.168.1 with HTTP; Fri, 22 Apr 2011 11:21:06 -0700 (PDT)
+X-Originating-Ip: [69.181.248.175]
+Date: Fri, 22 Apr 2011 11:21:06 -0700
+Message-Id: <BANLkTinHZL1QMDHOv7Ewp+Z5u6SPvYcc+Q@mail.gmail.com>
+Subject: Thanks!
+From: Kirk Douglas <dan@example.com>
+To: Bob Marley <bob@example.net>, Jimmy Hendrix <jimmy@examplehq.com>
+
+--===============4360815924781479146==
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: base64
+
+ZHVkZXMuLi4geW91J3JlIGtpY2tpbmcgYXNzLgrRh9GC0L7QsdGLINGPINCx0LXQtyDQstCw0YEg
+0LTQtdC70LDQuywg0LTQvtGA0L7Qs9C40LUg0LzQvtC4ISEhCgotLSAKRXYgS29udHNldm95LApD
+by1mb3VuZGVyIGFuZCBDRU8gb2YgTWFpbGd1bi5uZXQgLSB0aGUgZW1haWwgcGxhdGZvcm0gZm9y
+IGRldmVsb3BlcnMuCk1haWxndW46IHNlbmQsIHJlY2VpdmUsIHN0b3JlIGFuZCBzZWFyY2ggZW1h
+aWxzIQpwOiA1MTItNDE3LTE3NjIgIHwgIHQ6IEBtYWlsX2d1biAgfCAgdzogbWFpbGd1bi5uZXQK
+
+--===============4360815924781479146==
+Content-Type: text/html; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: base64
+
+ZHVkZXMuLi4geW91JiMzOTtyZSBraWNraW5nIGFzcy48ZGl2PtGH0YLQvtCx0Ysg0Y8g0LHQtdC3
+INCy0LDRgSDQtNC10LvQsNC7LCDQtNC+0YDQvtCz0LjQtSDQvNC+0LghISE8YnIgY2xlYXI9ImFs
+bCI+PGJyPi0tIDxicj5FdiBLb250c2V2b3ksJm5ic3A7PGRpdj48Zm9udCBjb2xvcj0iIzY2NjY2
+NiI+Q28tZm91bmRlciBhbmQgQ0VPIG9mJm5ic3A7PGEgaHJlZj0iaHR0cDovL01haWxndW4ubmV0
+IiB0YXJnZXQ9Il9ibGFuayI+TWFpbGd1bi5uZXQ8L2E+IC0gdGhlIGVtYWlsIHBsYXRmb3JtIGZv
+ciBkZXZlbG9wZXJzLjwvZm9udD48ZGl2Pgo8Zm9udCBjb2xvcj0iI0NDMDAwMCI+TWFpbGd1bjo8
+L2ZvbnQ+Jm5ic3A7PGZvbnQgY29sb3I9IiM2NjY2NjYiPnNlbmQsIHJlY2VpdmUsIHN0b3JlIGFu
+ZCBzZWFyY2ggZW1haWxzITwvZm9udD48YnI+PGZvbnQgY29sb3I9IiM2NjY2NjYiPnA6IDUxMi00
+MTctMTc2MiAmbmJzcDt8ICZuYnNwO3Q6IEBtYWlsX2d1biAmbmJzcDt8ICZuYnNwO3c6IDxhIGhy
+ZWY9Imh0dHA6Ly9tYWlsZ3VuLm5ldCIgdGFyZ2V0PSJfYmxhbmsiPm1haWxndW4ubmV0PC9hPjwv
+Zm9udD48L2Rpdj4KPC9kaXY+PGRpdj48YnI+PC9kaXY+PGJyPgo8L2Rpdj4K
+
+--===============4360815924781479146==--
+--===============6195527458677812340==--

--- a/tests/mime/message/scanner_test.py
+++ b/tests/mime/message/scanner_test.py
@@ -65,6 +65,33 @@ def enclosed_message_test():
     pbody = pbody.decode('utf-8')
     eq_(pbody, body)
 
+def enclosed_global_message_test():
+    message = scan(ENCLOSED_GLOBAL)
+    pmessage = _email.message_from_string(ENCLOSED_GLOBAL)
+
+    eq_(C('multipart', 'mixed',
+          dict(boundary='===============6195527458677812340==')),
+        message.content_type)
+    eq_(u'"Александр Клижентас☯" <bob@example.com>',
+        message.headers['To'])
+
+    eq_(pmessage.get_payload()[0].get_payload(), message.parts[0].body)
+
+    enclosed = message.parts[1]
+    penclosed = pmessage.get_payload(1)
+
+    eq_(('message/global', {'name': u'thanks.eml'},),
+        enclosed.headers['Content-Type'])
+
+    pbody = penclosed.get_payload()[0].get_payload()[0].get_payload(decode=True)
+    pbody = pbody.decode('utf-8')
+    body = enclosed.enclosed.parts[0].body
+    eq_(pbody, body)
+
+    body = enclosed.enclosed.parts[1].body
+    pbody = penclosed.get_payload()[0].get_payload()[1].get_payload(decode=True)
+    pbody = pbody.decode('utf-8')
+    eq_(pbody, body)
 
 def torture_message_test():
     message = scan(TORTURE)


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6532#section-3.7

> This media type provides
      functionality similar to the message/rfc822 content type for email
      messages with internationalized email headers.  When there is a
      need to embed or return such content in another message, there is
      generally an option to use this media type and leave the content
      unchanged or down-convert the content to message/rfc822.

This will allow us to correctly parse content embedded within `message/global` Content Types. Currently, this will result in an exception with the message `Malformed MIME message`.