### PR TITLE
Decode responses from redis

### DIFF
--- a/flanker/addresslib/drivers/redis_driver.py
+++ b/flanker/addresslib/drivers/redis_driver.py
@@ -15,7 +15,8 @@ class RedisCache(collections.MutableMapping):
         host = host or os.environ.get('REDIS_HOST', 'localhost')
         port = port or os.environ.get('REDIS_PORT', 6379)
         db = os.environ.get('REDIS_DB', 0)
-        self.r = redis.StrictRedis(host=host, port=port, db=db, decode_responses=True)
+        decode_resp = os.environ.get('REDIS_DECODE_RESPONSES', False)
+        self.r = redis.StrictRedis(host=host, port=port, db=db, decode_responses=decode_resp)
 
     def __getitem__(self, key):
         try:

--- a/flanker/addresslib/drivers/redis_driver.py
+++ b/flanker/addresslib/drivers/redis_driver.py
@@ -15,7 +15,7 @@ class RedisCache(collections.MutableMapping):
         host = host or os.environ.get('REDIS_HOST', 'localhost')
         port = port or os.environ.get('REDIS_PORT', 6379)
         db = os.environ.get('REDIS_DB', 0)
-        self.r = redis.StrictRedis(host=host, port=port, db=db)
+        self.r = redis.StrictRedis(host=host, port=port, db=db, decode_responses=True)
 
     def __getitem__(self, key):
         try:


### PR DESCRIPTION
FIxes:

```
    return_value = f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/address.py", line 322, in validate_address
    plugin = plugin_for_esp(exchanger)
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/validate.py", line 129, in plugin_for_esp
    if grammar[0].match(mail_exchanger):
TypeError: cannot use a string pattern on a bytes-like object
```