### PR TITLE
Fix future warning: escape [ in regex

### DIFF
--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -182,7 +182,7 @@ class MessageId(str):
 
 
 class Subject(six.text_type):
-    RE_RE = re.compile("((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
+    RE_RE = re.compile("((RE|FW|FWD|HA)([\[]\d])*:\s*)*", re.I)
 
     def __new__(cls, *args, **kw):
         return six.text_type.__new__(cls, *args, **kw)


### PR DESCRIPTION
Python >= 3.7 addes a future warning for unescaped [ characters.

References:
https://docs.python.org/dev/whatsnew/3.7.html#re
https://bugs.python.org/issue30349