### PR TITLE
Fix: TypeError: cannot use a string pattern on a bytes-like object

### DIFF
--- a/flanker/addresslib/address.py
+++ b/flanker/addresslib/address.py
@@ -310,6 +310,8 @@ def validate_address(addr_spec, metrics=False, skip_remote_checks=False):
 
     # lookup if this domain has a mail exchanger
     exchanger, mx_metrics = mail_exchanger_lookup(paddr.hostname, metrics=True)
+    if isinstance(exchanger, bytes):
+        exchanger = exchanger.decode()
     mtimes['mx_lookup'] = mx_metrics['mx_lookup']
     mtimes['dns_lookup'] = mx_metrics['dns_lookup']
     mtimes['mx_conn'] = mx_metrics['mx_conn']


### PR DESCRIPTION
Fixes #243 

Python 3 will not let you do a regex match using a byte-string.

```
Python 3.6.8 (v3.6.8:3c6b436a57, Dec 24 2018, 02:04:31)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

>>> import re
>>> hello = re.compile('hello')
>>>
>>> hello.match(b'hello')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: cannot use a string pattern on a bytes-like object
>>>
>>> hello.match(b'hello'.decode())
<_sre.SRE_Match object; span=(0, 5), match='hello'>
>>>
>>>