### PR TITLE
PIP-1217: properly encode non-ascii sender headers

### DIFF
--- a/flanker/mime/message/headers/encoding.py
+++ b/flanker/mime/message/headers/encoding.py
@@ -10,7 +10,7 @@ from flanker.mime.message.utils import to_utf8
 
 _log = logging.getLogger(__name__)
 
-_ADDRESS_HEADERS = ('From', 'To', 'Delivered-To', 'Cc', 'Bcc', 'Reply-To')
+_ADDRESS_HEADERS = ('From', 'To', 'Delivered-To', 'Cc', 'Bcc', 'Reply-To', 'Sender')
 
 
 def to_mime(key, value):


### PR DESCRIPTION
### Purpose
Encoding of the sender header is including encoded-words in the addr-spec. This breaks rfc standards. 

> These are the ONLY locations where an 'encoded-word' may appear.  In
>    particular:
> 
>    + An 'encoded-word' MUST NOT appear in any portion of an 'addr-spec'.

https://tools.ietf.org/html/rfc2047

### Implementation
Add Sender to the list of _ADDRESS_HEADERS so flanker will properly encode the header. 


https://mailgun.atlassian.net/browse/PIP-1217