### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/API Reference.md
+++ b/docs/API Reference.md
@@ -71,7 +71,7 @@ parse_list(address_list, strict=False, as_tuple=False)
 | strict         | Operate parser in strict (stop at any error) or relaxed (attempt to recover and continue). (Default: False) |
 | as_tuple       | Return just the parsed list addresses, or also the unparsed portions. (Default: False)                      |
 
-*Return Value*: If opearting in strict mode, returns a list of parsed EmailAddress objects. If operating
+*Return Value*: If operating in strict mode, returns a list of parsed EmailAddress objects. If operating
 in relaxed mode, can return a tuple that contains the parsed addresses and unparsable portions or just
 the parsed addresses in a list.
 
@@ -106,7 +106,7 @@ validate_list(addr_list, as_tuple=True)
 | address_list   | A delimiter (either `,` or `;`) separated list of addresses. (Maximum: 524288 characters) |
 | as_tuple       | Return just the parsed list addresses, or also the unparsed portions. (Default: False)    |
 
-*Return Value*: If opearting in strict mode, returns a list of parsed EmailAddress objects. If operating
+*Return Value*: If operating in strict mode, returns a list of parsed EmailAddress objects. If operating
 in relaxed mode, can return a tuple that contains the parsed addresses and unparsable portions or just
 the parsed addresses in a list.
 

--- a/docs/User Manual.md
+++ b/docs/User Manual.md
@@ -274,7 +274,7 @@ can loose some information because of broken or unknown encodings.
 #### Parsing MIME messages
 
 For the following examples, the below MIME messages will be used as examples, they will be
-refered to as `message_singlepart` and `message_multipart` respectivly.
+referred to as `message_singlepart` and `message_multipart` respectivly.
 
 **message_singlepart**:
 ```

--- a/tests/addresslib/plugins/aol_test.py
+++ b/tests/addresslib/plugins/aol_test.py
@@ -22,7 +22,7 @@ def mock_exchanger_lookup(arg, metrics=False):
 
 def test_exchanger_lookup():
     '''
-    Test if exchanger lookup is occuring correctly. If this simple test
+    Test if exchanger lookup is occurring correctly. If this simple test
     fails that means custom grammar was hit. Then the rest of the tests
     can be mocked. Should always be run during deployment, can be skipped
     during development.

--- a/tests/addresslib/plugins/gmail_test.py
+++ b/tests/addresslib/plugins/gmail_test.py
@@ -23,7 +23,7 @@ def mock_exchanger_lookup(arg, metrics=False):
 
 def test_exchanger_lookup():
     '''
-    Test if exchanger lookup is occuring correctly. If this simple test
+    Test if exchanger lookup is occurring correctly. If this simple test
     fails that means custom grammar was hit. Then the rest of the tests
     can be mocked. Should always be run during deployment, can be skipped
     during development.

--- a/tests/addresslib/plugins/google_test.py
+++ b/tests/addresslib/plugins/google_test.py
@@ -23,7 +23,7 @@ def mock_exchanger_lookup(arg, metrics=False):
 
 def test_exchanger_lookup():
     '''
-    Test if exchanger lookup is occuring correctly. If this simple test
+    Test if exchanger lookup is occurring correctly. If this simple test
     fails that means custom grammar was hit. Then the rest of the tests
     can be mocked. Should always be run during deployment, can be skipped
     during development.

--- a/tests/addresslib/plugins/hotmail_test.py
+++ b/tests/addresslib/plugins/hotmail_test.py
@@ -22,7 +22,7 @@ def mock_exchanger_lookup(arg, metrics=False):
 
 def test_exchanger_lookup():
     '''
-    Test if exchanger lookup is occuring correctly. If this simple test
+    Test if exchanger lookup is occurring correctly. If this simple test
     fails that means custom grammar was hit. Then the rest of the tests
     can be mocked. Should always be run during deployment, can be skipped
     during development.

--- a/tests/addresslib/plugins/icloud_test.py
+++ b/tests/addresslib/plugins/icloud_test.py
@@ -22,7 +22,7 @@ def mock_exchanger_lookup(arg, metrics=False):
 
 def test_exchanger_lookup():
     '''
-    Test if exchanger lookup is occuring correctly. If this simple test
+    Test if exchanger lookup is occurring correctly. If this simple test
     fails that means custom grammar was hit. Then the rest of the tests
     can be mocked. Should always be run during deployment, can be skipped
     during development.

--- a/tests/addresslib/plugins/yahoo_test.py
+++ b/tests/addresslib/plugins/yahoo_test.py
@@ -22,7 +22,7 @@ def mock_exchanger_lookup(arg, metrics=False):
 
 def test_exchanger_lookup():
     '''
-    Test if exchanger lookup is occuring correctly. If this simple test
+    Test if exchanger lookup is occurring correctly. If this simple test
     fails that means custom grammar was hit. Then the rest of the tests
     can be mocked. Should always be run during deployment, can be skipped
     during development.

--- a/tests/mime/message/headers/headers_test.py
+++ b/tests/mime/message/headers/headers_test.py
@@ -57,7 +57,7 @@ def headers_multiple_values_test():
     h.add('Received', '1')
     eq_(['1', '2', '4'], h.getall('Received'))
 
-    # use prepend to insert header in the begining of the list
+    # use prepend to insert header in the beginning of the list
     h.prepend('Received', '0')
     eq_(['0', '1', '2', '4'], h.getall('Received'))
 


### PR DESCRIPTION
There are small typos in:
- docs/API Reference.md
- docs/User Manual.md
- tests/addresslib/plugins/aol_test.py
- tests/addresslib/plugins/gmail_test.py
- tests/addresslib/plugins/google_test.py
- tests/addresslib/plugins/hotmail_test.py
- tests/addresslib/plugins/icloud_test.py
- tests/addresslib/plugins/yahoo_test.py
- tests/mime/message/headers/headers_test.py

Fixes:
- Should read `occurring` rather than `occuring`.
- Should read `referred` rather than `refered`.
- Should read `operating` rather than `opearting`.
- Should read `beginning` rather than `begining`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md