### PR TITLE
PIP-1966: Allow setting header fold chars

### DIFF
--- a/flanker/__init__.py
+++ b/flanker/__init__.py
@@ -1,1 +1,3 @@
 __version__ = '0.9.10'
+
+from flanker._email import set_header_fold_chars

--- a/flanker/_email.py
+++ b/flanker/_email.py
@@ -33,6 +33,11 @@ else:
     feedparser.NL = _CRLF
 
 
+def set_header_fold_chars(split_chars):
+    global _SPLIT_CHARS
+    _SPLIT_CHARS = split_chars
+
+
 def message_from_string(string):
     if six.PY3:
         if isinstance(string, six.binary_type):


### PR DESCRIPTION
* Introduces `flanker.set_header_fold_chars` function that can be used to change characters used to fold headers longer than 76 characters. By default the fold characters are ` `, `;`, and `,`. However folding on anything but ` ` can introduce extra spaces in the unfolded header. So `flanker.set_header_fold_chars(" ")` can be used to only fold on spaces and avoid the extra-spaces issue.  