### PR TITLE
Fix syntax warnings with Python 3.12

### DIFF
--- a/flanker/addresslib/plugins/gmail.py
+++ b/flanker/addresslib/plugins/gmail.py
@@ -23,7 +23,7 @@
         main-part        ->      alphanum { [dot] alphanum }
         tags             ->      { + [ dot-atom ] }
         dot-atom    	 ->      atom { [ dot   atom ] }
-        atom             ->      { A-Za-z0-9!#$%&'*+\-/=?^_`{|}~ }
+        atom             ->      { A-Za-z0-9!#$%&'*+\\-/=?^_`{|}~ }
         alphanum         ->      alpha | num
         dot              ->      .
 '''

--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -182,7 +182,7 @@ class MessageId(str):
 
 
 class Subject(six.text_type):
-    RE_RE = re.compile("((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
+    RE_RE = re.compile(r"((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
 
     def __new__(cls, *args, **kw):
         return six.text_type.__new__(cls, *args, **kw)


### PR DESCRIPTION
Python 3.12 issues warnings on invalid escape sequences in strings. (This was a `DeprecationWarning` since 3.6.)