### PR TITLE
Replace deprecated imghdr, switch to stable email.mime API

### DIFF
--- a/flanker/_email.py
+++ b/flanker/_email.py
@@ -82,10 +82,6 @@ def decode_quoted_printable(val):
     return email.quoprimime.header_decode(val)
 
 
-def detect_audio_type(val):
-    return audio._whatsnd(val)
-
-
 def make_message_id():
     return make_msgid()
 

--- a/flanker/mime/message/part.py
+++ b/flanker/mime/message/part.py
@@ -1,10 +1,11 @@
 import base64
-import imghdr
 import logging
 import mimetypes
 import quopri
 from contextlib import closing
 from os import path
+from email.mime.image import MIMEImage
+from email.mime.audio import MIMEAudio
 
 import six
 from six.moves import StringIO
@@ -113,14 +114,20 @@ def adjust_content_type(content_type, body=None, filename=None):
         if six.PY3 and isinstance(body, six.text_type):
             image_preamble = image_preamble.encode('utf-8', 'ignore')
 
-        sub = imghdr.what(None, image_preamble)
-        if sub:
-            content_type = ContentType('image', sub)
+        try:
+            mime = MIMEImage(image_preamble)
+        except TypeError:
+            pass
+        else:
+            content_type = ContentType(*mime.get_content_type().split('/'))
 
     elif content_type.main == 'audio' and body:
-        sub = _email.detect_audio_type(body)
-        if sub:
-            content_type = ContentType('audio', sub)
+        try:
+            mime = MIMEAudio(body)
+        except TypeError:
+            pass
+        else:
+            content_type = ContentType(*mime.get_content_type().split('/'))
 
     return content_type
 


### PR DESCRIPTION
The upcoming Python 3.13 [will remove](https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-dead-batteries) the built-in module `imghdr`.

Its mimetype-sniffing functionality was copied into `email.mime`, so I switched to it in `flanker/mime/message/part.py`.

The same file  also uses `email.mime.audio._whatsnd`, but since it's an internal underscore-prefixed function, it's not part of the stable API and was renamed in Python 3.11.

Instead of using `email.mime.audio._whatsnd`/`_what` and `imghdr`/`email.mime.image._what`, I think it's safer to use the stable wrapper classes `MIMEAudio`, `MIMEImage`, even though they require a bit more work to extract the sniffed content type.

If you disagree, I can switch back to using the internal function.

I tested this with Python 3.10 - please test with 2.7.

BTW, another deprecated module is `cgi`, which `webob` uses, but there's an open issue about it upstream, and I'm waiting to see if they intend to release a new version.