### PR TITLE
Simplify packaging configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-recursive-include tests *.py
-include LICENSE
-include MANIFEST.in
-include README.rst

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = [
 ],
 
 setup(name='flanker',
-      version='0.9.11',
+      version='0.9.16',
       description='Mailgun Parsing Tools',
       long_description=open('README.rst').read(),
       classifiers=[
@@ -28,7 +28,6 @@ setup(name='flanker',
       author_email='admin@mailgunhq.com',
       url='https://www.mailgun.com/',
       license='Apache 2',
-      packages=find_packages(exclude=['tests']),
       include_package_data=True,
       zip_safe=True,
       tests_require=tests_require,


### PR DESCRIPTION
We should be able to use setuptools' default package discovery mechanism without modification, since it supports both LICENSE and README.rst inclusion without the need for a separate MANIFEST.in.

This addresses a bug I encountered caused by a separate `tests` package being installed by pip as part of flanker's installation. 

Here's a fresh python install, with just pip in the site-packages:


```
james@Jamess-MBP-2 tmp-flanker % pyenv virtualenv tmp-flanker-fix
Looking in links: /var/folders/4h/2nsnlv397t92cv1fg6h1y2k40000gn/T/tmpppand0ob
Requirement already satisfied: pip in /Users/james/.pyenv/versions/tmp-flanker-fix/lib/python3.12/site-packages (24.0)
james@Jamess-MBP-2 tmp-flanker % pyenv local tmp-flanker-fix
(tmp-flanker-fix) james@Jamess-MBP-2 tmp-flanker % python -c "import site; print(site.getsitepackages())"
['/Users/james/.pyenv/versions/tmp-flanker-fix/lib/python3.12/site-packages']
(tmp-flanker-fix) james@Jamess-MBP-2 tmp-flanker % ls /Users/james/.pyenv/versions/tmp-flanker-fix/lib/python3.12/site-packages
pip			pip-24.0.dist-info
```

After installing flanker, notice the `tests` directory in site-packages:


```
(tmp-flanker-fix) james@Jamess-MBP-2 tmp-flanker % pip install flanker
...
Successfully installed WebOb-1.8.7 attrs-23.2.0 cffi-1.16.0 chardet-5.2.0 cryptography-42.0.5 flanker-0.9.11 idna-3.7 ply-3.11 pycparser-2.22 regex-2024.4.28 six-1.16.0 tld-0.13
(tmp-flanker-fix) james@Jamess-MBP-2 tmp-flanker % ls /Users/james/.pyenv/versions/tmp-flanker-fix/lib/python3.12/site-packages
WebOb-1.8.7.dist-info			attrs-23.2.0.dist-info			cryptography				idna-3.7.dist-info			pycparser				six.py
__pycache__				cffi					cryptography-42.0.5.dist-info		pip					pycparser-2.22.dist-info		**tests**
_cffi_backend.cpython-312-darwin.so	cffi-1.16.0.dist-info			flanker					pip-24.0.dist-info			regex					tld
attr					chardet					flanker-0.9.11.dist-info		ply					regex-2024.4.28.dist-info		tld-0.13.dist-info
attrs					chardet-5.2.0.dist-info			idna					ply-3.11.dist-info			six-1.16.0.dist-info			webob
```

And confirming the `test` directory is indeed coming from flanker:

```
(tmp-flanker-fix) james@Jamess-MBP-2 tmp-flanker % pip show -f flanker
Name: flanker
Version: 0.9.11
Summary: Mailgun Parsing Tools
Home-page: https://www.mailgun.com/
Author: Mailgun Technologies Inc.
Author-email: admin@mailgunhq.com
License: Apache 2
Location: /Users/james/.pyenv/versions/tmp-flanker-fix/lib/python3.12/site-packages
Requires: attrs, chardet, cryptography, idna, ply, regex, six, tld, WebOb
Required-by:
Files:
  flanker-0.9.11.dist-info/INSTALLER
  flanker-0.9.11.dist-info/LICENSE
  flanker-0.9.11.dist-info/METADATA
  flanker-0.9.11.dist-info/RECORD
  flanker-0.9.11.dist-info/REQUESTED
  flanker-0.9.11.dist-info/WHEEL
  flanker-0.9.11.dist-info/top_level.txt
  flanker-0.9.11.dist-info/zip-safe
  flanker/__init__.py
  ...
  flanker/mime/message/threading.py
  flanker/mime/message/utils.py
  flanker/utils.py
  tests/addresslib/__init__.py
  tests/addresslib/__pycache__/__init__.cpython-312.pyc
  tests/addresslib/__pycache__/address_test.cpython-312.pyc
  ...
  tests/mime/message/part_test.py
  tests/mime/message/scanner_test.py
  tests/mime/message/threading_test.py
  tests/mime/message/tokenizer_test.py
(tmp-flanker-fix) james@Jamess-MBP-2 tmp-flanker %
```